### PR TITLE
Fixed decimals in deposit

### DIFF
--- a/packages/sdk/src/sdk/sdk.deposit.ts
+++ b/packages/sdk/src/sdk/sdk.deposit.ts
@@ -101,7 +101,7 @@ export async function getDepositData<
     xcmFeeDecimals,
   ] = await Promise.all([
     // assetDecimals
-    polkadot.getAssetDecimals(asset),
+    asset.isNative ? moonChain.decimals : polkadot.getAssetDecimals(asset),
     // existentialDeposit
     foreignPolkadot.getExistentialDeposit(),
     // sourceBalance
@@ -153,7 +153,7 @@ export async function getDepositData<
     moonChainFee: {
       balance: xcmFeeBalance,
       decimals: xcmFeeAssetConfig.asset.isNative
-        ? meta.decimals
+        ? moonChain.decimals
         : xcmFeeDecimals,
       fee: xcmFee,
       symbol: xcmFeeAssetConfig.asset.originSymbol,


### PR DESCRIPTION
### Description

Decimals were wrong in a few places in DepositTransferData. For native assets (DEV, MOVR, GLMR).

### Checklist

- [x] If this requires a documentation change, I have created a PR in [moonbeam-docs](https://github.com/PureStake/moonbeam-docs) repository.
- [x] If this requires it, I have updated the Readme
- [x] If necessary, I have updated the examples
- [x] I have verified if I need to create/update unit tests
- [x] I have verified if I need to create/update acceptance tests
- [x] If necessary, I have run acceptance tests on this branch in CI
