### PR TITLE
Change toDecimal return type

### DIFF
--- a/examples/sdk-simple/index.ts
+++ b/examples/sdk-simple/index.ts
@@ -51,7 +51,10 @@ async function deposit() {
     `Your ${asset.originSymbol} balance in ${source.name}: ${toDecimal(
       sourceBalance,
       asset.decimals,
-    )}. Minimum transferable amount is: ${toDecimal(min, asset.decimals)}`,
+    ).toFixed()}. Minimum transferable amount is: ${toDecimal(
+      min,
+      asset.decimals,
+    ).toFixed()}`,
   );
 
   // sending enough to withdraw later
@@ -75,7 +78,10 @@ async function withdraw() {
     `Your ${asset.originSymbol} balance in ${destination.name}: ${toDecimal(
       destinationBalance,
       asset.decimals,
-    )}. Minimum transferable amount is: ${toDecimal(min, asset.decimals)}`,
+    ).toFixed()}. Minimum transferable amount is: ${toDecimal(
+      min,
+      asset.decimals,
+    ).toFixed()}`,
   );
 
   await send(min, (event) => console.log(event));
@@ -95,7 +101,7 @@ async function main() {
           `${balance.symbol}: ${toDecimal(
             balance.balance,
             balance.decimals,
-          )} (${origin.name} ${asset.originSymbol})`,
+          ).toFixed()} (${origin.name} ${asset.originSymbol})`,
         );
       });
       console.log('▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄');

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -83,9 +83,10 @@ const unsubscribe = await moonbeam.subscribeToAssetsBalanceInfo(
       // xcDOT: 0.073742 (Polkadot DOT)
       // ...
       console.log(
-        `${balance.symbol}: ${toDecimal(balance.balance, balance.decimals)} (${
-          origin.name
-        } ${asset.originSymbol})`,
+        `${balance.symbol}: ${toDecimal(
+          balance.balance,
+          balance.decimals,
+        ).toFixed()} (${origin.name} ${asset.originSymbol})`,
       );
     });
   },

--- a/packages/sdk/src/sdk/sdk.utils.ts
+++ b/packages/sdk/src/sdk/sdk.utils.ts
@@ -4,7 +4,6 @@ import {
   ChainKey,
   XcmConfigBuilder,
 } from '@moonbeam-network/xcm-config';
-import { toDecimal } from '@moonbeam-network/xcm-utils';
 import { UnsubscribePromise } from '@polkadot/api/types';
 import { AssetBalanceInfo, PolkadotService } from '../polkadot';
 import {
@@ -50,11 +49,8 @@ export function sortByBalanceAndChainName<Symbols extends AssetSymbol>(
     return 1;
   }
 
-  const aDecimal = toDecimal(a.balance.balance, a.balance.decimals);
-  const bDecimal = toDecimal(b.balance.balance, b.balance.decimals);
-
-  if (aDecimal || bDecimal) {
-    return bDecimal - aDecimal;
+  if (a.balance.balance || b.balance.balance) {
+    return Number(b.balance.balance - a.balance.balance);
   }
 
   const aName = (a.origin.name + a.asset.originSymbol).toLowerCase();

--- a/packages/utils/src/numbers/decimals.test.ts
+++ b/packages/utils/src/numbers/decimals.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable jest/no-focused-tests */
 /* eslint-disable jest/max-expects */
 import Big from 'big.js';
-import { toBigInt, toDecimal } from './decimals';
+import { hasDecimalOverflow, toBigInt, toDecimal } from './decimals';
 
 describe('utils - decimals', () => {
   describe('toDecimals', () => {
@@ -118,6 +118,29 @@ describe('utils - decimals', () => {
       expect(toBigInt('4756.50334457721117752', 18)).toBe(
         4_756_503_344_577_211_177_520n,
       );
+      expect(toBigInt('66712.0367386073069948646', 18)).toBe(
+        66_712_036_738_607_306_994_864n,
+      );
+    });
+  });
+
+  describe('hasDecimalOverflow', () => {
+    it('should return true if the value has more decimals that allowed', () => {
+      expect(hasDecimalOverflow('66712.0367386073069948646', 18)).toBe(true);
+      expect(hasDecimalOverflow('66712.0367386073069948645', 18)).toBe(true);
+      expect(hasDecimalOverflow('12.036073069948646', 12)).toBe(true);
+      expect(hasDecimalOverflow('12.0360730692110', 12)).toBe(true);
+      expect(hasDecimalOverflow('12.036073069', 12)).toBe(false);
+      expect(hasDecimalOverflow('12.036073069210', 12)).toBe(false);
+      expect(hasDecimalOverflow('66712.036738607306994864', 18)).toBe(false);
+      expect(hasDecimalOverflow(9.43535, 4)).toBe(true);
+    });
+
+    it('should return false if the value has a correct number of decimals', () => {
+      expect(hasDecimalOverflow('12.036073069', 12)).toBe(false);
+      expect(hasDecimalOverflow('12.036073069210', 12)).toBe(false);
+      expect(hasDecimalOverflow('66712.036738607306994864', 18)).toBe(false);
+      expect(hasDecimalOverflow(9.4353, 12)).toBe(false);
     });
   });
 });

--- a/packages/utils/src/numbers/decimals.test.ts
+++ b/packages/utils/src/numbers/decimals.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-focused-tests */
 /* eslint-disable jest/max-expects */
 import Big from 'big.js';
 import { toBigInt, toDecimal } from './decimals';
@@ -5,59 +6,83 @@ import { toBigInt, toDecimal } from './decimals';
 describe('utils - decimals', () => {
   describe('toDecimals', () => {
     it('should convert to decimals with 18 decimals', () => {
-      expect(toDecimal(1_678_578_001_143_648_100n, 18)).toBe('1.678578');
-      expect(toDecimal(4_778_448_942_696_649_000n, 18, 0)).toBe('5');
-      expect(toDecimal(9_277_414_529_928_219_000n, 18, 1)).toBe('9.3');
-      expect(toDecimal(1_489_926_767_190_488_000n, 18, 2)).toBe('1.49');
-      expect(toDecimal(7_111_587_933_365_016_000n, 18, 3)).toBe('7.112');
-      expect(toDecimal(7_111_587_933_365_016_000n, 18, 18)).toBe(
+      expect(toDecimal(1_678_578_001_143_648_100n, 18).toFixed()).toBe(
+        '1.678578',
+      );
+      expect(toDecimal(4_778_448_942_696_649_000n, 18, 0).toFixed()).toBe('5');
+      expect(toDecimal(9_277_414_529_928_219_000n, 18, 1).toFixed()).toBe(
+        '9.3',
+      );
+      expect(toDecimal(1_489_926_767_190_488_000n, 18, 2).toFixed()).toBe(
+        '1.49',
+      );
+      expect(toDecimal(7_111_587_933_365_016_000n, 18, 3).toFixed()).toBe(
+        '7.112',
+      );
+      expect(toDecimal(7_111_587_933_365_016_000n, 18, 18).toFixed()).toBe(
         '7.111587933365016',
       );
-      expect(toDecimal(4756503344577211177520n, 18, 18)).toBe(
+      expect(toDecimal(4756503344577211177520n, 18, 18).toFixed()).toBe(
         '4756.50334457721117752',
+      );
+      expect(toDecimal(198_000_012_317_550_812n, 18, 18).toFixed()).toBe(
+        '0.198000012317550812',
       );
     });
 
     it('should convert to decimals with 12 decimals', () => {
-      expect(toDecimal(52_912_391_280_480n, 12)).toBe('52.912391');
-      expect(toDecimal(796_301_020_21449n, 12, 0)).toBe('80');
-      expect(toDecimal(370_024_965_982_774n, 12, 1)).toBe('370');
-      expect(toDecimal(776_879_141_948n, 12, 2)).toBe('0.78');
-      expect(toDecimal(372_209_875_392n, 12, 3)).toBe('0.372');
-      expect(toDecimal(372_209_875_392n, 12, 12)).toBe('0.372209875392');
+      expect(toDecimal(52_912_391_280_480n, 12).toFixed()).toBe('52.912391');
+      expect(toDecimal(796_301_020_21449n, 12, 0).toFixed()).toBe('80');
+      expect(toDecimal(370_024_965_982_774n, 12, 1).toFixed()).toBe('370');
+      expect(toDecimal(776_879_141_948n, 12, 2).toFixed()).toBe('0.78');
+      expect(toDecimal(372_209_875_392n, 12, 3).toFixed()).toBe('0.372');
+      expect(toDecimal(372_209_875_392n, 12, 12).toFixed()).toBe(
+        '0.372209875392',
+      );
     });
 
     it('should convert to decimals from number', () => {
-      expect(toDecimal(167_857_800, 9)).toBe('0.167858');
-      expect(toDecimal(477_844_894, 9, 0)).toBe('0');
-      expect(toDecimal(927_741_452, 9, 1)).toBe('0.9');
-      expect(toDecimal(148_992_676, 9, 2)).toBe('0.15');
-      expect(toDecimal(711_158_793, 9, 3)).toBe('0.711');
-      expect(toDecimal(711_158_793, 9, 9)).toBe('0.711158793');
+      expect(toDecimal(167_857_800, 9).toFixed()).toBe('0.167858');
+      expect(toDecimal(477_844_894, 9, 0).toFixed()).toBe('0');
+      expect(toDecimal(927_741_452, 9, 1).toFixed()).toBe('0.9');
+      expect(toDecimal(148_992_676, 9, 2).toFixed()).toBe('0.15');
+      expect(toDecimal(711_158_793, 9, 3).toFixed()).toBe('0.711');
+      expect(toDecimal(711_158_793, 9, 9).toFixed()).toBe('0.711158793');
     });
 
     it('should convert to decimals from string', () => {
-      expect(toDecimal('167_857_800', 9)).toBe('0.167858');
-      expect(toDecimal('167_857_800n', 9)).toBe('0.167858');
-      expect(toDecimal('477_844_894', 9, 0)).toBe('0');
-      expect(toDecimal('927_741_452', 9, 1)).toBe('0.9');
-      expect(toDecimal('148_992_676', 9, 2)).toBe('0.15');
-      expect(toDecimal('711_158_793', 9, 3)).toBe('0.711');
-      expect(toDecimal('711_158_793', 9, 9)).toBe('0.711158793');
-      expect(toDecimal('711_158_793n', 9, 9)).toBe('0.711158793');
+      expect(toDecimal('167_857_800', 9).toFixed()).toBe('0.167858');
+      expect(toDecimal('167_857_800n', 9).toFixed()).toBe('0.167858');
+      expect(toDecimal('477_844_894', 9, 0).toFixed()).toBe('0');
+      expect(toDecimal('927_741_452', 9, 1).toFixed()).toBe('0.9');
+      expect(toDecimal('148_992_676', 9, 2).toFixed()).toBe('0.15');
+      expect(toDecimal('711_158_793', 9, 3).toFixed()).toBe('0.711');
+      expect(toDecimal('711_158_793', 9, 9).toFixed()).toBe('0.711158793');
+      expect(toDecimal('711_158_793n', 9, 9).toFixed()).toBe('0.711158793');
     });
 
     it('should convert to decimals with the correct rounding types', () => {
-      expect(toDecimal(477_844_894, 9, 0)).toBe('0');
-      expect(toDecimal(370_024_965_982_774n, 12, 1, Big.roundDown)).toBe('370');
-      expect(toDecimal(477_844_894, 9, 0, Big.roundUp)).toBe('1');
-      expect(toDecimal('167_850_000n', 9, 4, Big.roundHalfEven)).toBe('0.1678');
-      expect(toDecimal('7_117_587_933_365_016_000', 18, 2)).toBe('7.12');
-      expect(toDecimal('7_117_587_933_365_016_000', 18, 2, Big.roundDown)).toBe(
-        '7.11',
+      expect(toDecimal(477_844_894, 9, 0).toFixed()).toBe('0');
+      expect(
+        toDecimal(370_024_965_982_774n, 12, 1, Big.roundDown).toFixed(),
+      ).toBe('370');
+      expect(toDecimal(477_844_894, 9, 0, Big.roundUp).toFixed()).toBe('1');
+      expect(toDecimal('167_850_000n', 9, 4, Big.roundHalfEven).toFixed()).toBe(
+        '0.1678',
+      );
+      expect(toDecimal('7_117_587_933_365_016_000', 18, 2).toFixed()).toBe(
+        '7.12',
       );
       expect(
-        toDecimal('7_117_587_933_365_016_000', 18, 2, Big.roundHalfUp),
+        toDecimal('7_117_587_933_365_016_000', 18, 2, Big.roundDown).toFixed(),
+      ).toBe('7.11');
+      expect(
+        toDecimal(
+          '7_117_587_933_365_016_000',
+          18,
+          2,
+          Big.roundHalfUp,
+        ).toFixed(),
       ).toBe('7.12');
     });
   });
@@ -90,6 +115,9 @@ describe('utils - decimals', () => {
       expect(toBigInt(0.78, 12)).toBe(780_000_000_000n);
       expect(toBigInt(0.372, 12)).toBe(372_000_000_000n);
       expect(toBigInt(0.372209875392, 12)).toBe(372_209_875_392n);
+      expect(toBigInt('4756.50334457721117752', 18)).toBe(
+        4_756_503_344_577_211_177_520n,
+      );
     });
   });
 });

--- a/packages/utils/src/numbers/decimals.test.ts
+++ b/packages/utils/src/numbers/decimals.test.ts
@@ -5,57 +5,60 @@ import { toBigInt, toDecimal } from './decimals';
 describe('utils - decimals', () => {
   describe('toDecimals', () => {
     it('should convert to decimals with 18 decimals', () => {
-      expect(toDecimal(1_678_578_001_143_648_100n, 18)).toBe(1.678578);
-      expect(toDecimal(4_778_448_942_696_649_000n, 18, 0)).toBe(5);
-      expect(toDecimal(9_277_414_529_928_219_000n, 18, 1)).toBe(9.3);
-      expect(toDecimal(1_489_926_767_190_488_000n, 18, 2)).toBe(1.49);
-      expect(toDecimal(7_111_587_933_365_016_000n, 18, 3)).toBe(7.112);
+      expect(toDecimal(1_678_578_001_143_648_100n, 18)).toBe('1.678578');
+      expect(toDecimal(4_778_448_942_696_649_000n, 18, 0)).toBe('5');
+      expect(toDecimal(9_277_414_529_928_219_000n, 18, 1)).toBe('9.3');
+      expect(toDecimal(1_489_926_767_190_488_000n, 18, 2)).toBe('1.49');
+      expect(toDecimal(7_111_587_933_365_016_000n, 18, 3)).toBe('7.112');
       expect(toDecimal(7_111_587_933_365_016_000n, 18, 18)).toBe(
-        7.111587933365016,
+        '7.111587933365016',
+      );
+      expect(toDecimal(4756503344577211177520n, 18, 18)).toBe(
+        '4756.50334457721117752',
       );
     });
 
     it('should convert to decimals with 12 decimals', () => {
-      expect(toDecimal(52_912_391_280_480n, 12)).toBe(52.912391);
-      expect(toDecimal(796_301_020_21449n, 12, 0)).toBe(80);
-      expect(toDecimal(370_024_965_982_774n, 12, 1)).toBe(370);
-      expect(toDecimal(776_879_141_948n, 12, 2)).toBe(0.78);
-      expect(toDecimal(372_209_875_392n, 12, 3)).toBe(0.372);
-      expect(toDecimal(372_209_875_392n, 12, 12)).toBe(0.372209875392);
+      expect(toDecimal(52_912_391_280_480n, 12)).toBe('52.912391');
+      expect(toDecimal(796_301_020_21449n, 12, 0)).toBe('80');
+      expect(toDecimal(370_024_965_982_774n, 12, 1)).toBe('370');
+      expect(toDecimal(776_879_141_948n, 12, 2)).toBe('0.78');
+      expect(toDecimal(372_209_875_392n, 12, 3)).toBe('0.372');
+      expect(toDecimal(372_209_875_392n, 12, 12)).toBe('0.372209875392');
     });
 
     it('should convert to decimals from number', () => {
-      expect(toDecimal(167_857_800, 9)).toBe(0.167858);
-      expect(toDecimal(477_844_894, 9, 0)).toBe(0);
-      expect(toDecimal(927_741_452, 9, 1)).toBe(0.9);
-      expect(toDecimal(148_992_676, 9, 2)).toBe(0.15);
-      expect(toDecimal(711_158_793, 9, 3)).toBe(0.711);
-      expect(toDecimal(711_158_793, 9, 9)).toBe(0.711158793);
+      expect(toDecimal(167_857_800, 9)).toBe('0.167858');
+      expect(toDecimal(477_844_894, 9, 0)).toBe('0');
+      expect(toDecimal(927_741_452, 9, 1)).toBe('0.9');
+      expect(toDecimal(148_992_676, 9, 2)).toBe('0.15');
+      expect(toDecimal(711_158_793, 9, 3)).toBe('0.711');
+      expect(toDecimal(711_158_793, 9, 9)).toBe('0.711158793');
     });
 
     it('should convert to decimals from string', () => {
-      expect(toDecimal('167_857_800', 9)).toBe(0.167858);
-      expect(toDecimal('167_857_800n', 9)).toBe(0.167858);
-      expect(toDecimal('477_844_894', 9, 0)).toBe(0);
-      expect(toDecimal('927_741_452', 9, 1)).toBe(0.9);
-      expect(toDecimal('148_992_676', 9, 2)).toBe(0.15);
-      expect(toDecimal('711_158_793', 9, 3)).toBe(0.711);
-      expect(toDecimal('711_158_793', 9, 9)).toBe(0.711158793);
-      expect(toDecimal('711_158_793n', 9, 9)).toBe(0.711158793);
+      expect(toDecimal('167_857_800', 9)).toBe('0.167858');
+      expect(toDecimal('167_857_800n', 9)).toBe('0.167858');
+      expect(toDecimal('477_844_894', 9, 0)).toBe('0');
+      expect(toDecimal('927_741_452', 9, 1)).toBe('0.9');
+      expect(toDecimal('148_992_676', 9, 2)).toBe('0.15');
+      expect(toDecimal('711_158_793', 9, 3)).toBe('0.711');
+      expect(toDecimal('711_158_793', 9, 9)).toBe('0.711158793');
+      expect(toDecimal('711_158_793n', 9, 9)).toBe('0.711158793');
     });
 
     it('should convert to decimals with the correct rounding types', () => {
-      expect(toDecimal(477_844_894, 9, 0)).toBe(0);
-      expect(toDecimal(370_024_965_982_774n, 12, 1, Big.roundDown)).toBe(370);
-      expect(toDecimal(477_844_894, 9, 0, Big.roundUp)).toBe(1);
-      expect(toDecimal('167_850_000n', 9, 4, Big.roundHalfEven)).toBe(0.1678);
-      expect(toDecimal('7_117_587_933_365_016_000', 18, 2)).toBe(7.12);
+      expect(toDecimal(477_844_894, 9, 0)).toBe('0');
+      expect(toDecimal(370_024_965_982_774n, 12, 1, Big.roundDown)).toBe('370');
+      expect(toDecimal(477_844_894, 9, 0, Big.roundUp)).toBe('1');
+      expect(toDecimal('167_850_000n', 9, 4, Big.roundHalfEven)).toBe('0.1678');
+      expect(toDecimal('7_117_587_933_365_016_000', 18, 2)).toBe('7.12');
       expect(toDecimal('7_117_587_933_365_016_000', 18, 2, Big.roundDown)).toBe(
-        7.11,
+        '7.11',
       );
       expect(
         toDecimal('7_117_587_933_365_016_000', 18, 2, Big.roundHalfUp),
-      ).toBe(7.12);
+      ).toBe('7.12');
     });
   });
 

--- a/packages/utils/src/numbers/decimals.test.ts
+++ b/packages/utils/src/numbers/decimals.test.ts
@@ -130,9 +130,6 @@ describe('utils - decimals', () => {
       expect(hasDecimalOverflow('66712.0367386073069948645', 18)).toBe(true);
       expect(hasDecimalOverflow('12.036073069948646', 12)).toBe(true);
       expect(hasDecimalOverflow('12.0360730692110', 12)).toBe(true);
-      expect(hasDecimalOverflow('12.036073069', 12)).toBe(false);
-      expect(hasDecimalOverflow('12.036073069210', 12)).toBe(false);
-      expect(hasDecimalOverflow('66712.036738607306994864', 18)).toBe(false);
       expect(hasDecimalOverflow(9.43535, 4)).toBe(true);
     });
 
@@ -141,6 +138,9 @@ describe('utils - decimals', () => {
       expect(hasDecimalOverflow('12.036073069210', 12)).toBe(false);
       expect(hasDecimalOverflow('66712.036738607306994864', 18)).toBe(false);
       expect(hasDecimalOverflow(9.4353, 12)).toBe(false);
+      expect(hasDecimalOverflow('12.036073069', 12)).toBe(false);
+      expect(hasDecimalOverflow('12.036073069210', 12)).toBe(false);
+      expect(hasDecimalOverflow('66712.036738607306994864', 18)).toBe(false);
     });
   });
 });

--- a/packages/utils/src/numbers/decimals.ts
+++ b/packages/utils/src/numbers/decimals.ts
@@ -5,12 +5,12 @@ export function toDecimal(
   decimals: number,
   maxDecimal = 6,
   roundType?: RoundingMode,
-): number {
+): string {
   const dividend = Big(number.toString().replace(/[^0-9]/g, ''));
   const divisor = Big(10).pow(decimals);
   const result = dividend.div(divisor).round(maxDecimal, roundType);
 
-  return result.toNumber();
+  return result.toFixed();
 }
 
 export function toBigInt(amount: string | number, decimals: number): bigint {

--- a/packages/utils/src/numbers/decimals.ts
+++ b/packages/utils/src/numbers/decimals.ts
@@ -5,12 +5,12 @@ export function toDecimal(
   decimals: number,
   maxDecimal = 6,
   roundType?: RoundingMode,
-): string {
+): Big {
   const dividend = Big(number.toString().replace(/[^0-9]/g, ''));
   const divisor = Big(10).pow(decimals);
   const result = dividend.div(divisor).round(maxDecimal, roundType);
 
-  return result.toFixed();
+  return result;
 }
 
 export function toBigInt(amount: string | number, decimals: number): bigint {

--- a/packages/utils/src/numbers/decimals.ts
+++ b/packages/utils/src/numbers/decimals.ts
@@ -17,5 +17,10 @@ export function toBigInt(amount: string | number, decimals: number): bigint {
   const multiplier = Big(10).pow(decimals);
   const result = Big(amount).mul(multiplier);
 
-  return BigInt(result.toFixed());
+  return BigInt(result.toFixed(0, 0));
+}
+
+export function hasDecimalOverflow(fl: number | string, maxDecimal: number) {
+  const parts = fl.toString().split('.');
+  return parts.length > 1 && parts[1].length > maxDecimal;
 }

--- a/packages/utils/src/numbers/decimals.ts
+++ b/packages/utils/src/numbers/decimals.ts
@@ -17,7 +17,7 @@ export function toBigInt(amount: string | number, decimals: number): bigint {
   const multiplier = Big(10).pow(decimals);
   const result = Big(amount).mul(multiplier);
 
-  return BigInt(result.toFixed(0, 0));
+  return BigInt(result.toFixed(0, Big.roundDown));
 }
 
 export function hasDecimalOverflow(fl: number | string, maxDecimal: number) {


### PR DESCRIPTION
### Description

Change return type of `toDecimal` function to `Big` type from `big.js`.

### Checklist

- [x] If this requires a documentation change, I have created a PR in [moonbeam-docs](https://github.com/PureStake/moonbeam-docs) repository.
- [x] If this requires it, I have updated the Readme
- [x] If necessary, I have updated the examples
- [x] I have verified if I need to create/update unit tests
- [x] I have verified if I need to create/update acceptance tests
- [x] If necessary, I have run acceptance tests on this branch in CI

Docs PR: 
https://github.com/PureStake/moonbeam-docs/pull/561