### PR TITLE
Autodetect ML version available for polkdotXcm extrinsics

### DIFF
--- a/packages/config/src/config/moonbase/assets/tt1.ts
+++ b/packages/config/src/config/moonbase/assets/tt1.ts
@@ -28,7 +28,7 @@ export const TT1: MoonbaseXcmConfig = {
         .limitedReserveTransferAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
         .origin(origin)
-        .V1()
+        .V1V2()
         .X2(getPalletInstance(origin), originAssetId),
     },
   },

--- a/packages/config/src/config/moonbase/assets/tt1.ts
+++ b/packages/config/src/config/moonbase/assets/tt1.ts
@@ -27,7 +27,6 @@ export const TT1: MoonbaseXcmConfig = {
         .polkadotXcm()
         .limitedReserveTransferAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-        .origin(origin)
         .V1V2()
         .X2(getPalletInstance(origin), originAssetId),
     },

--- a/packages/config/src/config/moonbase/assets/unit.ts
+++ b/packages/config/src/config/moonbase/assets/unit.ts
@@ -23,8 +23,7 @@ export const UNIT: MoonbaseXcmConfig = {
         .xcmPallet()
         .limitedReserveTransferAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-        .origin(origin)
-        .V2(),
+        .origin(origin),
     },
   },
   withdraw: {

--- a/packages/config/src/config/moonbase/assets/unit.ts
+++ b/packages/config/src/config/moonbase/assets/unit.ts
@@ -22,8 +22,7 @@ export const UNIT: MoonbaseXcmConfig = {
       extrinsic: extrinsic
         .xcmPallet()
         .limitedReserveTransferAssets()
-        .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-        .origin(origin),
+        .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted),
     },
   },
   withdraw: {

--- a/packages/config/src/config/moonbeam/assets/astr.ts
+++ b/packages/config/src/config/moonbeam/assets/astr.ts
@@ -23,7 +23,6 @@ export const ASTR: MoonbeamXcmConfig = {
         .polkadotXcm()
         .limitedReserveTransferAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-        .origin(origin)
         .V1V2()
         .here(),
     },

--- a/packages/config/src/config/moonbeam/assets/astr.ts
+++ b/packages/config/src/config/moonbeam/assets/astr.ts
@@ -24,7 +24,7 @@ export const ASTR: MoonbeamXcmConfig = {
         .limitedReserveTransferAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
         .origin(origin)
-        .V1()
+        .V1V2()
         .here(),
     },
   },

--- a/packages/config/src/config/moonbeam/assets/dot.ts
+++ b/packages/config/src/config/moonbeam/assets/dot.ts
@@ -23,8 +23,7 @@ export const DOT: MoonbeamXcmConfig = {
         .xcmPallet()
         .limitedReserveTransferAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-        .origin(origin)
-        .V0(),
+        .origin(origin),
     },
   },
   withdraw: {

--- a/packages/config/src/config/moonbeam/assets/dot.ts
+++ b/packages/config/src/config/moonbeam/assets/dot.ts
@@ -22,8 +22,7 @@ export const DOT: MoonbeamXcmConfig = {
       extrinsic: extrinsic
         .xcmPallet()
         .limitedReserveTransferAssets()
-        .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-        .origin(origin),
+        .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted),
     },
   },
   withdraw: {

--- a/packages/config/src/config/moonbeam/assets/glmr.ts
+++ b/packages/config/src/config/moonbeam/assets/glmr.ts
@@ -55,7 +55,7 @@ export const GLMR: MoonbeamXcmConfig = {
         .limitedReserveWithdrawAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
         .origin(astar)
-        .V1()
+        .V1V2()
         .X2(getPalletInstance(astar)),
     },
     [bifrost.key]: {

--- a/packages/config/src/config/moonbeam/assets/glmr.ts
+++ b/packages/config/src/config/moonbeam/assets/glmr.ts
@@ -54,7 +54,6 @@ export const GLMR: MoonbeamXcmConfig = {
         .polkadotXcm()
         .limitedReserveWithdrawAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-        .origin(astar)
         .V1V2()
         .X2(getPalletInstance(astar)),
     },

--- a/packages/config/src/config/moonbeam/assets/ring.ts
+++ b/packages/config/src/config/moonbeam/assets/ring.ts
@@ -24,7 +24,7 @@ export const RING: MoonbeamXcmConfig = {
         .limitedReserveTransferAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
         .origin(origin)
-        .V1()
+        .V1V2()
         .X1(),
     },
   },

--- a/packages/config/src/config/moonbeam/assets/ring.ts
+++ b/packages/config/src/config/moonbeam/assets/ring.ts
@@ -23,7 +23,6 @@ export const RING: MoonbeamXcmConfig = {
         .polkadotXcm()
         .limitedReserveTransferAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-        .origin(origin)
         .V1V2()
         .X1(),
     },

--- a/packages/config/src/config/moonbeam/assets/usdt.ts
+++ b/packages/config/src/config/moonbeam/assets/usdt.ts
@@ -27,7 +27,6 @@ export const USDT: MoonbeamXcmConfig = {
         .polkadotXcm()
         .limitedReserveTransferAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-        .origin(origin)
         .V1V2()
         .X2(getPalletInstance(origin), originAssetId),
     },

--- a/packages/config/src/config/moonbeam/assets/usdt.ts
+++ b/packages/config/src/config/moonbeam/assets/usdt.ts
@@ -28,7 +28,7 @@ export const USDT: MoonbeamXcmConfig = {
         .limitedReserveTransferAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
         .origin(origin)
-        .V1()
+        .V1V2()
         .X2(getPalletInstance(origin), originAssetId),
     },
   },

--- a/packages/config/src/config/moonriver/assets/crab.ts
+++ b/packages/config/src/config/moonriver/assets/crab.ts
@@ -23,7 +23,6 @@ export const CRAB: MoonriverXcmConfig = {
         .polkadotXcm()
         .limitedReserveTransferAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-        .origin(origin)
         .V1V2()
         .X1(),
     },

--- a/packages/config/src/config/moonriver/assets/crab.ts
+++ b/packages/config/src/config/moonriver/assets/crab.ts
@@ -24,7 +24,7 @@ export const CRAB: MoonriverXcmConfig = {
         .limitedReserveTransferAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
         .origin(origin)
-        .V1()
+        .V1V2()
         .X1(),
     },
   },

--- a/packages/config/src/config/moonriver/assets/csm.ts
+++ b/packages/config/src/config/moonriver/assets/csm.ts
@@ -23,7 +23,6 @@ export const CSM: MoonriverXcmConfig = {
         .polkadotXcm()
         .limitedReserveTransferAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-        .origin(origin)
         .V1V2()
         .here(),
     },

--- a/packages/config/src/config/moonriver/assets/csm.ts
+++ b/packages/config/src/config/moonriver/assets/csm.ts
@@ -24,7 +24,8 @@ export const CSM: MoonriverXcmConfig = {
         .limitedReserveTransferAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
         .origin(origin)
-        .V0(),
+        .V1V2()
+        .here(),
     },
   },
   withdraw: {

--- a/packages/config/src/config/moonriver/assets/ksm.ts
+++ b/packages/config/src/config/moonriver/assets/ksm.ts
@@ -23,8 +23,7 @@ export const KSM: MoonriverXcmConfig = {
         .xcmPallet()
         .limitedReserveTransferAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-        .origin(origin)
-        .V0(),
+        .origin(origin),
     },
   },
   withdraw: {

--- a/packages/config/src/config/moonriver/assets/ksm.ts
+++ b/packages/config/src/config/moonriver/assets/ksm.ts
@@ -22,8 +22,7 @@ export const KSM: MoonriverXcmConfig = {
       extrinsic: extrinsic
         .xcmPallet()
         .limitedReserveTransferAssets()
-        .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-        .origin(origin),
+        .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted),
     },
   },
   withdraw: {

--- a/packages/config/src/config/moonriver/assets/movr.ts
+++ b/packages/config/src/config/moonriver/assets/movr.ts
@@ -118,7 +118,6 @@ export const MOVR: MoonriverXcmConfig = {
         .polkadotXcm()
         .limitedReserveWithdrawAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-        .origin(shiden)
         .V1V2()
         .X2(getPalletInstance(shiden)),
     },

--- a/packages/config/src/config/moonriver/assets/movr.ts
+++ b/packages/config/src/config/moonriver/assets/movr.ts
@@ -119,7 +119,7 @@ export const MOVR: MoonriverXcmConfig = {
         .limitedReserveWithdrawAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
         .origin(shiden)
-        .V1()
+        .V1V2()
         .X2(getPalletInstance(shiden)),
     },
   },

--- a/packages/config/src/config/moonriver/assets/rmrk.ts
+++ b/packages/config/src/config/moonriver/assets/rmrk.ts
@@ -28,7 +28,7 @@ export const RMRK: MoonriverXcmConfig = {
         .limitedReserveTransferAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
         .origin(origin)
-        .V1()
+        .V1V2()
         .X2(getPalletInstance(origin), originAssetId),
     },
   },

--- a/packages/config/src/config/moonriver/assets/rmrk.ts
+++ b/packages/config/src/config/moonriver/assets/rmrk.ts
@@ -27,7 +27,6 @@ export const RMRK: MoonriverXcmConfig = {
         .polkadotXcm()
         .limitedReserveTransferAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-        .origin(origin)
         .V1V2()
         .X2(getPalletInstance(origin), originAssetId),
     },

--- a/packages/config/src/config/moonriver/assets/sdn.ts
+++ b/packages/config/src/config/moonriver/assets/sdn.ts
@@ -24,7 +24,7 @@ export const SDN: MoonriverXcmConfig = {
         .limitedReserveTransferAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
         .origin(origin)
-        .V1()
+        .V1V2()
         .here(),
     },
   },

--- a/packages/config/src/config/moonriver/assets/sdn.ts
+++ b/packages/config/src/config/moonriver/assets/sdn.ts
@@ -23,7 +23,6 @@ export const SDN: MoonriverXcmConfig = {
         .polkadotXcm()
         .limitedReserveTransferAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-        .origin(origin)
         .V1V2()
         .here(),
     },

--- a/packages/config/src/config/moonriver/assets/usdt.ts
+++ b/packages/config/src/config/moonriver/assets/usdt.ts
@@ -28,7 +28,7 @@ export const USDT: MoonriverXcmConfig = {
         .limitedReserveTransferAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
         .origin(origin)
-        .V1()
+        .V1V2()
         .X2(getPalletInstance(origin), originAssetId),
     },
   },

--- a/packages/config/src/config/moonriver/assets/usdt.ts
+++ b/packages/config/src/config/moonriver/assets/usdt.ts
@@ -27,7 +27,6 @@ export const USDT: MoonriverXcmConfig = {
         .polkadotXcm()
         .limitedReserveTransferAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-        .origin(origin)
         .V1V2()
         .X2(getPalletInstance(origin), originAssetId),
     },

--- a/packages/config/src/config/moonriver/assets/xrt.ts
+++ b/packages/config/src/config/moonriver/assets/xrt.ts
@@ -24,7 +24,7 @@ export const XRT: MoonriverXcmConfig = {
         .limitedReserveTransferAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
         .origin(origin)
-        .V1()
+        .V1V2()
         .here(),
     },
   },

--- a/packages/config/src/config/moonriver/assets/xrt.ts
+++ b/packages/config/src/config/moonriver/assets/xrt.ts
@@ -23,7 +23,6 @@ export const XRT: MoonriverXcmConfig = {
         .polkadotXcm()
         .limitedReserveTransferAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-        .origin(origin)
         .V1V2()
         .here(),
     },

--- a/packages/config/src/extrinsic/extrinsic.ts
+++ b/packages/config/src/extrinsic/extrinsic.ts
@@ -10,8 +10,8 @@ export function createExtrinsicBuilder<
   ChainKeys extends ChainKey,
 >(chain: MoonChain) {
   return {
-    polkadotXcm: () => polkadotXcm<ChainKeys>(chain),
-    xcmPallet: () => xcmPallet<ChainKeys>(chain),
+    polkadotXcm: () => polkadotXcm(chain),
+    xcmPallet: () => xcmPallet(chain),
     xTokens: () => xTokens<Symbols, ChainKeys>(chain),
     xTransfer: () => xTransfer<ChainKeys>(chain),
   };

--- a/packages/config/src/extrinsic/polkadotXcm/__snapshots__/polkadotXcm.test.ts.snap
+++ b/packages/config/src/extrinsic/polkadotXcm/__snapshots__/polkadotXcm.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`polkadotXcm limitedReserveTransferAssets v0 should be correct config 1`] = `
+exports[`polkadotXcm limitedReserveTransferAssets v1v2 here should be correct config 1`] = `
 {
   "extrinsic": "limitedReserveTransferAssets",
   "getParams": [Function],
@@ -9,58 +9,7 @@ exports[`polkadotXcm limitedReserveTransferAssets v0 should be correct config 1`
 }
 `;
 
-exports[`polkadotXcm limitedReserveTransferAssets v0 should get correct params 1`] = `
-[
-  {
-    "V1": {
-      "interior": {
-        "X1": {
-          "Parachain": 1000,
-        },
-      },
-      "parents": 1,
-    },
-  },
-  {
-    "V1": {
-      "interior": {
-        "X1": {
-          "AccountKey20": {
-            "key": "0xeF46c7649270C912704fB09B75097f6E32208b85",
-            "network": "Any",
-          },
-        },
-      },
-      "parents": 0,
-    },
-  },
-  {
-    "V0": [
-      {
-        "ConcreteFungible": {
-          "amount": 1000n,
-          "id": "Null",
-        },
-      },
-    ],
-  },
-  0,
-  {
-    "Limited": 1000000000,
-  },
-]
-`;
-
-exports[`polkadotXcm limitedReserveTransferAssets v1 here should be correct config 1`] = `
-{
-  "extrinsic": "limitedReserveTransferAssets",
-  "getParams": [Function],
-  "pallet": "polkadotXcm",
-  "successEvent": "Attempted",
-}
-`;
-
-exports[`polkadotXcm limitedReserveTransferAssets v1 here should get correct params 1`] = `
+exports[`polkadotXcm limitedReserveTransferAssets v1v2 here should get correct params 1`] = `
 [
   {
     "V1": {
@@ -101,13 +50,11 @@ exports[`polkadotXcm limitedReserveTransferAssets v1 here should get correct par
     ],
   },
   0,
-  {
-    "Limited": 1000000000,
-  },
+  "Unlimited",
 ]
 `;
 
-exports[`polkadotXcm limitedReserveTransferAssets v1 x1 should be correct config 1`] = `
+exports[`polkadotXcm limitedReserveTransferAssets v1v2 x1 should be correct config 1`] = `
 {
   "extrinsic": "limitedReserveTransferAssets",
   "getParams": [Function],
@@ -116,7 +63,7 @@ exports[`polkadotXcm limitedReserveTransferAssets v1 x1 should be correct config
 }
 `;
 
-exports[`polkadotXcm limitedReserveTransferAssets v1 x1 should get correct params 1`] = `
+exports[`polkadotXcm limitedReserveTransferAssets v1v2 x1 should get correct params 1`] = `
 [
   {
     "V1": {
@@ -161,13 +108,11 @@ exports[`polkadotXcm limitedReserveTransferAssets v1 x1 should get correct param
     ],
   },
   0,
-  {
-    "Limited": 1000000000,
-  },
+  "Unlimited",
 ]
 `;
 
-exports[`polkadotXcm limitedReserveTransferAssets v1 x2 should be correct config 1`] = `
+exports[`polkadotXcm limitedReserveTransferAssets v1v2 x2 should be correct config 1`] = `
 {
   "extrinsic": "limitedReserveTransferAssets",
   "getParams": [Function],
@@ -176,7 +121,7 @@ exports[`polkadotXcm limitedReserveTransferAssets v1 x2 should be correct config
 }
 `;
 
-exports[`polkadotXcm limitedReserveTransferAssets v1 x2 should get correct params 1`] = `
+exports[`polkadotXcm limitedReserveTransferAssets v1v2 x2 should get correct params 1`] = `
 [
   {
     "V1": {
@@ -226,13 +171,11 @@ exports[`polkadotXcm limitedReserveTransferAssets v1 x2 should get correct param
     ],
   },
   0,
-  {
-    "Limited": 1000000000,
-  },
+  "Unlimited",
 ]
 `;
 
-exports[`polkadotXcm limitedReserveWithdrawAssets v1 x2 should be correct config 1`] = `
+exports[`polkadotXcm limitedReserveWithdrawAssets v1v2 x2 should be correct config 1`] = `
 {
   "extrinsic": "limitedReserveWithdrawAssets",
   "getParams": [Function],
@@ -241,7 +184,7 @@ exports[`polkadotXcm limitedReserveWithdrawAssets v1 x2 should be correct config
 }
 `;
 
-exports[`polkadotXcm limitedReserveWithdrawAssets v1 x2 should get correct params 1`] = `
+exports[`polkadotXcm limitedReserveWithdrawAssets v1v2 x2 should get correct params 1`] = `
 [
   {
     "V1": {
@@ -291,8 +234,6 @@ exports[`polkadotXcm limitedReserveWithdrawAssets v1 x2 should get correct param
     ],
   },
   0,
-  {
-    "Limited": 1000000000,
-  },
+  "Unlimited",
 ]
 `;

--- a/packages/config/src/extrinsic/polkadotXcm/polkadotXcm.interfaces.ts
+++ b/packages/config/src/extrinsic/polkadotXcm/polkadotXcm.interfaces.ts
@@ -13,12 +13,12 @@ export interface PolkadotXcmPallet {
   getParams: (params: XcmExtrinsicGetParams) => PolkadotXcmPalletParams;
 }
 
-export type PolkadotXcmPalletParamsV1 = [
+export type PolkadotXcmPalletParams = [
   /**
    * destination
    */
   {
-    V1: {
+    [v in XcmMLVersion]?: {
       parents: Parents;
       interior: {
         X1: {
@@ -31,7 +31,7 @@ export type PolkadotXcmPalletParamsV1 = [
    * beneficiary
    */
   {
-    V1: {
+    [v in XcmMLVersion]?: {
       parents: 0;
       interior: {
         X1: {
@@ -49,56 +49,9 @@ export type PolkadotXcmPalletParamsV1 = [
   /**
    * asset
    */
-  PolkadotXcmAssetParam,
-  /**
-   * fee
-   */
-  0,
-  /**
-   * weight
-   */
   {
-    Limited: number;
+    [v in XcmMLVersion]?: PolkadotXcmAssetParam[];
   },
-];
-
-export type PolkadotXcmPalletParamsV2 = [
-  /**
-   * destination
-   */
-  {
-    V2: {
-      parents: Parents;
-      interior: {
-        X1: {
-          Parachain: number;
-        };
-      };
-    };
-  },
-  /**
-   * beneficiary
-   */
-  {
-    V2: {
-      parents: 0;
-      interior: {
-        X1: {
-          AccountKey20: {
-            network: 'Any';
-            /**
-             * account
-             */
-            key: string;
-          };
-        };
-      };
-    };
-  },
-  /**
-   * asset
-   */
-  PolkadotXcmAssetParam,
   /**
    * fee
    */
@@ -109,52 +62,32 @@ export type PolkadotXcmPalletParamsV2 = [
   'Unlimited',
 ];
 
-export type PolkadotXcmPalletParams =
-  | PolkadotXcmPalletParamsV1
-  | PolkadotXcmPalletParamsV2;
-
-export type PolkadotXcmAssetParam =
-  | PolkadotXcmAssetParamV0
-  | PolkadotXcmAssetParamV1
-  | PolkadotXcmAssetParamV2;
-
-export interface PolkadotXcmAssetParamV0 {
-  V0: [
-    {
-      ConcreteFungible: {
-        id: 'Null';
-        amount: bigint;
-      };
-    },
-  ];
+export enum XcmMLVersion {
+  v1 = 'V1',
+  v2 = 'V2',
 }
+export type PolkadotXcmAssetParam = {
+  id: {
+    Concrete: {
+      parents: Parents;
+      interior:
+        | 'Here'
+        | PolkadotXcmAssetParamInteriorX1
+        | PolkadotXcmAssetParamInteriorX2;
+    };
+  };
+  fun: {
+    Fungible: bigint;
+  };
+};
 
-export interface PolkadotXcmAssetParamV1 {
-  V1: [
-    {
-      id: {
-        Concrete: {
-          parents: Parents;
-          interior:
-            | 'Here'
-            | PolkadotXcmAssetParamV1InteriorX1
-            | PolkadotXcmAssetParamV1InteriorX2;
-        };
-      };
-      fun: {
-        Fungible: bigint;
-      };
-    },
-  ];
-}
-
-export interface PolkadotXcmAssetParamV1InteriorX1 {
+export interface PolkadotXcmAssetParamInteriorX1 {
   X1: {
     PalletInstance: number;
   };
 }
 
-export interface PolkadotXcmAssetParamV1InteriorX2 {
+export interface PolkadotXcmAssetParamInteriorX2 {
   X2:
     | [
         {
@@ -172,29 +105,4 @@ export interface PolkadotXcmAssetParamV1InteriorX2 {
           PalletInstance: number;
         },
       ];
-}
-
-export interface PolkadotXcmAssetParamV2 {
-  V2: [
-    {
-      id: {
-        Concrete: {
-          parents: Parents;
-          interior:
-            | 'Here'
-            | PolkadotXcmAssetParamV1InteriorX1
-            | PolkadotXcmAssetParamV1InteriorX2;
-        };
-      };
-      fun: {
-        Fungible: bigint;
-      };
-    },
-  ];
-}
-
-export enum XcmMLVersion {
-  v0 = 'V0',
-  v1 = 'V1',
-  v2 = 'V2',
 }

--- a/packages/config/src/extrinsic/polkadotXcm/polkadotXcm.test.ts
+++ b/packages/config/src/extrinsic/polkadotXcm/polkadotXcm.test.ts
@@ -1,5 +1,5 @@
-import { ChainKey, MoonChainKey } from '../../constants';
-import { Chain, MoonChain } from '../../interfaces';
+import { MoonChainKey } from '../../constants';
+import { MoonChain } from '../../interfaces';
 import { polkadotXcm } from './polkadotXcm';
 import { PolkadotXcmExtrinsicSuccessEvent } from './polkadotXcm.constants';
 
@@ -15,16 +15,6 @@ describe('polkadotXcm', () => {
     chainId: 1287,
     unitsPerSecond: 100n,
   };
-  const origin: Chain = {
-    key: ChainKey.AlphanetRelay,
-    name: 'Alphanet Relay',
-    ws: 'wss://frag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network',
-    weight: 1_000_000_000,
-    parachainId: 0,
-    ss58Format: 42,
-    genesisHash:
-      '0xe1ea3ab1d46ba8f4898b6b4b9c54ffc05282d299f89e84bd0fd08067758c9443',
-  };
   const extrinsic = polkadotXcm(chain);
 
   describe('limitedReserveTransferAssets', () => {
@@ -33,7 +23,6 @@ describe('polkadotXcm', () => {
         const cfg = extrinsic
           .limitedReserveTransferAssets()
           .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-          .origin(origin)
           .V1V2()
           .here();
 
@@ -50,7 +39,6 @@ describe('polkadotXcm', () => {
         const cfg = extrinsic
           .limitedReserveTransferAssets()
           .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-          .origin(origin)
           .V1V2()
           .X1();
 
@@ -67,7 +55,6 @@ describe('polkadotXcm', () => {
         const cfg = extrinsic
           .limitedReserveTransferAssets()
           .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-          .origin(origin)
           .V1V2()
           .X2(10, 50);
 
@@ -88,7 +75,6 @@ describe('polkadotXcm', () => {
         const cfg = extrinsic
           .limitedReserveWithdrawAssets()
           .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-          .origin(origin)
           .V1V2()
           .X2(10);
 

--- a/packages/config/src/extrinsic/polkadotXcm/polkadotXcm.test.ts
+++ b/packages/config/src/extrinsic/polkadotXcm/polkadotXcm.test.ts
@@ -28,29 +28,13 @@ describe('polkadotXcm', () => {
   const extrinsic = polkadotXcm(chain);
 
   describe('limitedReserveTransferAssets', () => {
-    describe('v0', () => {
-      const cfg = extrinsic
-        .limitedReserveTransferAssets()
-        .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-        .origin(origin)
-        .V0();
-
-      it('should be correct config', () => {
-        expect(cfg).toMatchSnapshot();
-      });
-
-      it('should get correct params', () => {
-        expect(cfg.getParams({ account, amount })).toMatchSnapshot();
-      });
-    });
-
-    describe('v1', () => {
+    describe('v1v2', () => {
       describe('here', () => {
         const cfg = extrinsic
           .limitedReserveTransferAssets()
           .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
           .origin(origin)
-          .V1()
+          .V1V2()
           .here();
 
         it('should be correct config', () => {
@@ -67,7 +51,7 @@ describe('polkadotXcm', () => {
           .limitedReserveTransferAssets()
           .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
           .origin(origin)
-          .V1()
+          .V1V2()
           .X1();
 
         it('should be correct config', () => {
@@ -84,7 +68,7 @@ describe('polkadotXcm', () => {
           .limitedReserveTransferAssets()
           .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
           .origin(origin)
-          .V1()
+          .V1V2()
           .X2(10, 50);
 
         it('should be correct config', () => {
@@ -99,13 +83,13 @@ describe('polkadotXcm', () => {
   });
 
   describe('limitedReserveWithdrawAssets', () => {
-    describe('v1', () => {
+    describe('v1v2', () => {
       describe('x2', () => {
         const cfg = extrinsic
           .limitedReserveWithdrawAssets()
           .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
           .origin(origin)
-          .V1()
+          .V1V2()
           .X2(10);
 
         it('should be correct config', () => {

--- a/packages/config/src/extrinsic/polkadotXcm/polkadotXcm.ts
+++ b/packages/config/src/extrinsic/polkadotXcm/polkadotXcm.ts
@@ -4,8 +4,7 @@ import {
   PolkadotXcmExtrinsic,
   PolkadotXcmExtrinsicSuccessEvent,
 } from './polkadotXcm.constants';
-import { XcmMLVersion } from './polkadotXcm.interfaces';
-import { getCreateExtrinsic } from './polkadotXcm.util';
+import { getCreateV1V2Extrinsic } from './polkadotXcm.util';
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
 export function polkadotXcm<ChainKeys extends ChainKey>(chain: MoonChain) {
@@ -23,7 +22,7 @@ function limitedReserveTransferAssets<ChainKeys extends ChainKey>(
   return {
     successEvent: (event: PolkadotXcmExtrinsicSuccessEvent) => ({
       origin: (origin: Chain<ChainKeys>) => {
-        const createExtrinsic = getCreateExtrinsic(
+        const createExtrinsic = getCreateV1V2Extrinsic(
           PolkadotXcmExtrinsic.LimitedReserveTransferAssets,
           event,
           chain,
@@ -31,91 +30,62 @@ function limitedReserveTransferAssets<ChainKeys extends ChainKey>(
         );
 
         return {
-          V0: () =>
-            createExtrinsic(
-              (amount) => ({
-                V0: [
-                  {
-                    ConcreteFungible: {
-                      id: 'Null',
-                      amount,
+          V1V2: () => ({
+            here: () =>
+              createExtrinsic((amount) => [
+                {
+                  id: {
+                    Concrete: {
+                      parents: 0,
+                      interior: 'Here',
                     },
                   },
-                ],
-              }),
-              XcmMLVersion.v0,
-            ),
-          V1: () => ({
-            here: () =>
-              createExtrinsic(
-                (amount) => ({
-                  V1: [
-                    {
-                      id: {
-                        Concrete: {
-                          parents: 0,
-                          interior: 'Here',
-                        },
-                      },
-                      fun: {
-                        Fungible: amount,
-                      },
-                    },
-                  ],
-                }),
-                XcmMLVersion.v1,
-              ),
+                  fun: {
+                    Fungible: amount,
+                  },
+                },
+              ]),
             X1: () =>
-              createExtrinsic(
-                (amount) => ({
-                  V1: [
-                    {
-                      id: {
-                        Concrete: {
-                          parents: 0,
-                          interior: {
-                            X1: {
-                              PalletInstance: 5,
-                            },
-                          },
+              createExtrinsic((amount) => [
+                {
+                  id: {
+                    Concrete: {
+                      parents: 0,
+                      interior: {
+                        X1: {
+                          PalletInstance: 5,
                         },
                       },
-                      fun: {
-                        Fungible: amount,
-                      },
                     },
-                  ],
-                }),
-                XcmMLVersion.v1,
-              ),
+                  },
+                  fun: {
+                    Fungible: amount,
+                  },
+                },
+              ]),
             X2: (palletInstance: number, assetId: AssetId) =>
-              createExtrinsic(
-                (amount) => ({
-                  V1: [
-                    {
-                      id: {
-                        Concrete: {
-                          parents: 0,
-                          interior: {
-                            X2: [
-                              {
-                                PalletInstance: palletInstance,
-                              },
-                              {
-                                GeneralIndex: assetId,
-                              },
-                            ],
+              createExtrinsic((amount) => [
+                {
+                  id: {
+                    Concrete: {
+                      parents: 0,
+                      interior: {
+                        X2: [
+                          {
+                            PalletInstance: palletInstance,
                           },
-                        },
-                      },
-                      fun: {
-                        Fungible: amount,
+                          {
+                            GeneralIndex: assetId,
+                          },
+                        ],
                       },
                     },
-                  ],
-                }),
-                XcmMLVersion.v1,
-              ),
+                  },
+                  fun: {
+                    Fungible: amount,
+                  },
+                },
+              ]),
           }),
         };
       },
@@ -129,7 +99,7 @@ function limitedReserveWithdrawAssets<ChainKeys extends ChainKey>(
   return {
     successEvent: (event: PolkadotXcmExtrinsicSuccessEvent) => ({
       origin: (origin: Chain<ChainKeys>) => {
-        const createExtrinsic = getCreateExtrinsic(
+        const createExtrinsic = getCreateV1V2Extrinsic(
           PolkadotXcmExtrinsic.LimitedReserveWithdrawAssets,
           event,
           chain,
@@ -137,35 +107,30 @@ function limitedReserveWithdrawAssets<ChainKeys extends ChainKey>(
         );
 
         return {
-          V1: () => ({
+          V1V2: () => ({
             X2: (palletInstance: number) =>
-              createExtrinsic(
-                (amount) => ({
-                  V1: [
-                    {
-                      id: {
-                        Concrete: {
-                          parents: 1,
-                          interior: {
-                            X2: [
-                              {
-                                Parachain: chain.parachainId,
-                              },
-                              {
-                                PalletInstance: palletInstance,
-                              },
-                            ],
+              createExtrinsic((amount) => [
+                {
+                  id: {
+                    Concrete: {
+                      parents: 1,
+                      interior: {
+                        X2: [
+                          {
+                            Parachain: chain.parachainId,
                           },
-                        },
-                      },
-                      fun: {
-                        Fungible: amount,
+                          {
+                            PalletInstance: palletInstance,
+                          },
+                        ],
                       },
                     },
-                  ],
-                }),
-                XcmMLVersion.v1,
-              ),
+                  },
+                  fun: {
+                    Fungible: amount,
+                  },
+                },
+              ]),
           }),
         };
       },

--- a/packages/config/src/extrinsic/polkadotXcm/polkadotXcm.ts
+++ b/packages/config/src/extrinsic/polkadotXcm/polkadotXcm.ts
@@ -1,5 +1,4 @@
-import { ChainKey } from '../../constants';
-import { AssetId, Chain, MoonChain } from '../../interfaces';
+import { AssetId, MoonChain } from '../../interfaces';
 import {
   PolkadotXcmExtrinsic,
   PolkadotXcmExtrinsicSuccessEvent,
@@ -7,133 +6,121 @@ import {
 import { getCreateV1V2Extrinsic } from './polkadotXcm.util';
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
-export function polkadotXcm<ChainKeys extends ChainKey>(chain: MoonChain) {
+export function polkadotXcm(chain: MoonChain) {
   return {
-    limitedReserveTransferAssets: () =>
-      limitedReserveTransferAssets<ChainKeys>(chain),
-    limitedReserveWithdrawAssets: () =>
-      limitedReserveWithdrawAssets<ChainKeys>(chain),
+    limitedReserveTransferAssets: () => limitedReserveTransferAssets(chain),
+    limitedReserveWithdrawAssets: () => limitedReserveWithdrawAssets(chain),
   };
 }
 
-function limitedReserveTransferAssets<ChainKeys extends ChainKey>(
-  chain: MoonChain,
-) {
+function limitedReserveTransferAssets(chain: MoonChain) {
   return {
-    successEvent: (event: PolkadotXcmExtrinsicSuccessEvent) => ({
-      origin: (origin: Chain<ChainKeys>) => {
-        const createExtrinsic = getCreateV1V2Extrinsic(
-          PolkadotXcmExtrinsic.LimitedReserveTransferAssets,
-          event,
-          chain,
-          origin,
-        );
+    successEvent: (event: PolkadotXcmExtrinsicSuccessEvent) => {
+      const createExtrinsic = getCreateV1V2Extrinsic(
+        PolkadotXcmExtrinsic.LimitedReserveTransferAssets,
+        event,
+        chain,
+      );
 
-        return {
-          V1V2: () => ({
-            here: () =>
-              createExtrinsic((amount) => [
-                {
-                  id: {
-                    Concrete: {
-                      parents: 0,
-                      interior: 'Here',
-                    },
-                  },
-                  fun: {
-                    Fungible: amount,
+      return {
+        V1V2: () => ({
+          here: () =>
+            createExtrinsic((amount) => [
+              {
+                id: {
+                  Concrete: {
+                    parents: 0,
+                    interior: 'Here',
                   },
                 },
-              ]),
-            X1: () =>
-              createExtrinsic((amount) => [
-                {
-                  id: {
-                    Concrete: {
-                      parents: 0,
-                      interior: {
-                        X1: {
-                          PalletInstance: 5,
+                fun: {
+                  Fungible: amount,
+                },
+              },
+            ]),
+          X1: () =>
+            createExtrinsic((amount) => [
+              {
+                id: {
+                  Concrete: {
+                    parents: 0,
+                    interior: {
+                      X1: {
+                        PalletInstance: 5,
+                      },
+                    },
+                  },
+                },
+                fun: {
+                  Fungible: amount,
+                },
+              },
+            ]),
+          X2: (palletInstance: number, assetId: AssetId) =>
+            createExtrinsic((amount) => [
+              {
+                id: {
+                  Concrete: {
+                    parents: 0,
+                    interior: {
+                      X2: [
+                        {
+                          PalletInstance: palletInstance,
                         },
-                      },
+                        {
+                          GeneralIndex: assetId,
+                        },
+                      ],
                     },
                   },
-                  fun: {
-                    Fungible: amount,
-                  },
                 },
-              ]),
-            X2: (palletInstance: number, assetId: AssetId) =>
-              createExtrinsic((amount) => [
-                {
-                  id: {
-                    Concrete: {
-                      parents: 0,
-                      interior: {
-                        X2: [
-                          {
-                            PalletInstance: palletInstance,
-                          },
-                          {
-                            GeneralIndex: assetId,
-                          },
-                        ],
-                      },
-                    },
-                  },
-                  fun: {
-                    Fungible: amount,
-                  },
+                fun: {
+                  Fungible: amount,
                 },
-              ]),
-          }),
-        };
-      },
-    }),
+              },
+            ]),
+        }),
+      };
+    },
   };
 }
 
-function limitedReserveWithdrawAssets<ChainKeys extends ChainKey>(
-  chain: MoonChain,
-) {
+function limitedReserveWithdrawAssets(chain: MoonChain) {
   return {
-    successEvent: (event: PolkadotXcmExtrinsicSuccessEvent) => ({
-      origin: (origin: Chain<ChainKeys>) => {
-        const createExtrinsic = getCreateV1V2Extrinsic(
-          PolkadotXcmExtrinsic.LimitedReserveWithdrawAssets,
-          event,
-          chain,
-          origin,
-        );
+    successEvent: (event: PolkadotXcmExtrinsicSuccessEvent) => {
+      const createExtrinsic = getCreateV1V2Extrinsic(
+        PolkadotXcmExtrinsic.LimitedReserveWithdrawAssets,
+        event,
+        chain,
+      );
 
-        return {
-          V1V2: () => ({
-            X2: (palletInstance: number) =>
-              createExtrinsic((amount) => [
-                {
-                  id: {
-                    Concrete: {
-                      parents: 1,
-                      interior: {
-                        X2: [
-                          {
-                            Parachain: chain.parachainId,
-                          },
-                          {
-                            PalletInstance: palletInstance,
-                          },
-                        ],
-                      },
+      return {
+        V1V2: () => ({
+          X2: (palletInstance: number) =>
+            createExtrinsic((amount) => [
+              {
+                id: {
+                  Concrete: {
+                    parents: 1,
+                    interior: {
+                      X2: [
+                        {
+                          Parachain: chain.parachainId,
+                        },
+                        {
+                          PalletInstance: palletInstance,
+                        },
+                      ],
                     },
                   },
-                  fun: {
-                    Fungible: amount,
-                  },
                 },
-              ]),
-          }),
-        };
-      },
-    }),
+                fun: {
+                  Fungible: amount,
+                },
+              },
+            ]),
+        }),
+      };
+    },
   };
 }

--- a/packages/config/src/extrinsic/polkadotXcm/polkadotXcm.util.ts
+++ b/packages/config/src/extrinsic/polkadotXcm/polkadotXcm.util.ts
@@ -1,7 +1,6 @@
 import { SubmittableExtrinsicFunction } from '@polkadot/api/types';
 import { getTypeDef } from '@polkadot/types/create';
-import { ChainKey } from '../../constants';
-import { Chain, MoonChain } from '../../interfaces';
+import { MoonChain } from '../../interfaces';
 import { Parents } from '../common.interfaces';
 import { ExtrinsicPallet } from '../extrinsic.constants';
 import {
@@ -30,11 +29,10 @@ function getAvailableVersion(
   return XcmMLVersion.v1;
 }
 
-export function getCreateV1V2Extrinsic<ChainKeys extends ChainKey>(
+export function getCreateV1V2Extrinsic(
   extrinsic: PolkadotXcmExtrinsic,
   event: PolkadotXcmExtrinsicSuccessEvent,
   config: MoonChain,
-  origin: Chain<ChainKeys>,
   parents: Parents = 1,
 ) {
   return (

--- a/packages/config/src/extrinsic/xcmPallet/__snapshots__/xcmPallet.test.ts.snap
+++ b/packages/config/src/extrinsic/xcmPallet/__snapshots__/xcmPallet.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`xcmPallet limitedReserveTransferAssets v1v2 should be correct config 1`] = `
+exports[`xcmPallet limitedReserveTransferAssets should be correct config 1`] = `
 {
   "extrinsic": "limitedReserveTransferAssets",
   "getParams": [Function],
@@ -9,7 +9,7 @@ exports[`xcmPallet limitedReserveTransferAssets v1v2 should be correct config 1`
 }
 `;
 
-exports[`xcmPallet limitedReserveTransferAssets v1v2 should get correct params 1`] = `
+exports[`xcmPallet limitedReserveTransferAssets should get correct params 1`] = `
 [
   {
     "V1": {

--- a/packages/config/src/extrinsic/xcmPallet/__snapshots__/xcmPallet.test.ts.snap
+++ b/packages/config/src/extrinsic/xcmPallet/__snapshots__/xcmPallet.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`xcmPallet limitedReserveTransferAssets v0 should be correct config 1`] = `
+exports[`xcmPallet limitedReserveTransferAssets v1v2 should be correct config 1`] = `
 {
   "extrinsic": "limitedReserveTransferAssets",
   "getParams": [Function],
@@ -9,7 +9,7 @@ exports[`xcmPallet limitedReserveTransferAssets v0 should be correct config 1`] 
 }
 `;
 
-exports[`xcmPallet limitedReserveTransferAssets v0 should get correct params 1`] = `
+exports[`xcmPallet limitedReserveTransferAssets v1v2 should get correct params 1`] = `
 [
   {
     "V1": {
@@ -35,58 +35,7 @@ exports[`xcmPallet limitedReserveTransferAssets v0 should get correct params 1`]
     },
   },
   {
-    "V0": [
-      {
-        "ConcreteFungible": {
-          "amount": 1000n,
-          "id": "Null",
-        },
-      },
-    ],
-  },
-  0,
-  {
-    "Limited": 1000000000,
-  },
-]
-`;
-
-exports[`xcmPallet limitedReserveTransferAssets v2 should be correct config 1`] = `
-{
-  "extrinsic": "limitedReserveTransferAssets",
-  "getParams": [Function],
-  "pallet": "xcmPallet",
-  "successEvent": "Attempted",
-}
-`;
-
-exports[`xcmPallet limitedReserveTransferAssets v2 should get correct params 1`] = `
-[
-  {
-    "V2": {
-      "interior": {
-        "X1": {
-          "Parachain": 1000,
-        },
-      },
-      "parents": 0,
-    },
-  },
-  {
-    "V2": {
-      "interior": {
-        "X1": {
-          "AccountKey20": {
-            "key": "0xeF46c7649270C912704fB09B75097f6E32208b85",
-            "network": "Any",
-          },
-        },
-      },
-      "parents": 0,
-    },
-  },
-  {
-    "V2": [
+    "V1": [
       {
         "fun": {
           "Fungible": 1000n,

--- a/packages/config/src/extrinsic/xcmPallet/xcmPallet.test.ts
+++ b/packages/config/src/extrinsic/xcmPallet/xcmPallet.test.ts
@@ -28,28 +28,11 @@ describe('xcmPallet', () => {
   const extrinsic = xcmPallet(chain);
 
   describe('limitedReserveTransferAssets', () => {
-    describe('v0', () => {
+    describe('v1v2', () => {
       const cfg = extrinsic
         .limitedReserveTransferAssets()
         .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-        .origin(origin)
-        .V0();
-
-      it('should be correct config', () => {
-        expect(cfg).toMatchSnapshot();
-      });
-
-      it('should get correct params', () => {
-        expect(cfg.getParams({ account, amount })).toMatchSnapshot();
-      });
-    });
-
-    describe('v2', () => {
-      const cfg = extrinsic
-        .limitedReserveTransferAssets()
-        .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-        .origin(origin)
-        .V2();
+        .origin(origin);
 
       it('should be correct config', () => {
         expect(cfg).toMatchSnapshot();

--- a/packages/config/src/extrinsic/xcmPallet/xcmPallet.test.ts
+++ b/packages/config/src/extrinsic/xcmPallet/xcmPallet.test.ts
@@ -1,5 +1,5 @@
-import { ChainKey, MoonChainKey } from '../../constants';
-import { Chain, MoonChain } from '../../interfaces';
+import { MoonChainKey } from '../../constants';
+import { MoonChain } from '../../interfaces';
 import { PolkadotXcmExtrinsicSuccessEvent } from '../polkadotXcm';
 import { xcmPallet } from './xcmPallet';
 
@@ -15,32 +15,20 @@ describe('xcmPallet', () => {
     chainId: 1287,
     unitsPerSecond: 100n,
   };
-  const origin: Chain = {
-    key: ChainKey.AlphanetRelay,
-    name: 'Alphanet Relay',
-    ws: 'wss://frag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network',
-    weight: 1_000_000_000,
-    parachainId: 0,
-    ss58Format: 42,
-    genesisHash:
-      '0xe1ea3ab1d46ba8f4898b6b4b9c54ffc05282d299f89e84bd0fd08067758c9443',
-  };
+
   const extrinsic = xcmPallet(chain);
 
   describe('limitedReserveTransferAssets', () => {
-    describe('v1v2', () => {
-      const cfg = extrinsic
-        .limitedReserveTransferAssets()
-        .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
-        .origin(origin);
+    const cfg = extrinsic
+      .limitedReserveTransferAssets()
+      .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted);
 
-      it('should be correct config', () => {
-        expect(cfg).toMatchSnapshot();
-      });
+    it('should be correct config', () => {
+      expect(cfg).toMatchSnapshot();
+    });
 
-      it('should get correct params', () => {
-        expect(cfg.getParams({ account, amount })).toMatchSnapshot();
-      });
+    it('should get correct params', () => {
+      expect(cfg.getParams({ account, amount })).toMatchSnapshot();
     });
   });
 });

--- a/packages/config/src/extrinsic/xcmPallet/xcmPallet.ts
+++ b/packages/config/src/extrinsic/xcmPallet/xcmPallet.ts
@@ -2,10 +2,9 @@ import { ChainKey } from '../../constants';
 import { Chain, MoonChain } from '../../interfaces';
 import { ExtrinsicPallet } from '../extrinsic.constants';
 import {
-  getCreateExtrinsic,
+  getCreateV1V2Extrinsic,
   PolkadotXcmExtrinsic,
   PolkadotXcmExtrinsicSuccessEvent,
-  XcmMLVersion,
 } from '../polkadotXcm';
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -22,7 +21,7 @@ function limitedReserveTransferAssets<ChainKeys extends ChainKey>(
   return {
     successEvent: (event: PolkadotXcmExtrinsicSuccessEvent) => ({
       origin: (origin: Chain<ChainKeys>) => {
-        const createExtrinsic = getCreateExtrinsic(
+        const createExtrinsic = getCreateV1V2Extrinsic(
           PolkadotXcmExtrinsic.LimitedReserveTransferAssets,
           event,
           chain,
@@ -31,43 +30,20 @@ function limitedReserveTransferAssets<ChainKeys extends ChainKey>(
         );
 
         return {
-          V0: () => ({
-            ...createExtrinsic(
-              (amount) => ({
-                V0: [
-                  {
-                    ConcreteFungible: {
-                      id: 'Null',
-                      amount,
-                    },
-                  },
-                ],
-              }),
-              XcmMLVersion.v0,
-            ),
-            pallet: ExtrinsicPallet.XcmPallet,
-          }),
-          V2: () => ({
-            ...createExtrinsic(
-              (amount) => ({
-                V2: [
-                  {
-                    id: {
-                      Concrete: {
-                        parents: 0,
-                        interior: 'Here',
-                      },
-                    },
-                    fun: {
-                      Fungible: amount,
-                    },
-                  },
-                ],
-              }),
-              XcmMLVersion.v2,
-            ),
-            pallet: ExtrinsicPallet.XcmPallet,
-          }),
+          ...createExtrinsic((amount) => [
+            {
+              id: {
+                Concrete: {
+                  parents: 0,
+                  interior: 'Here',
+                },
+              },
+              fun: {
+                Fungible: amount,
+              },
+            },
+          ]),
+          pallet: ExtrinsicPallet.XcmPallet,
         };
       },
     }),

--- a/packages/config/src/extrinsic/xcmPallet/xcmPallet.ts
+++ b/packages/config/src/extrinsic/xcmPallet/xcmPallet.ts
@@ -1,5 +1,4 @@
-import { ChainKey } from '../../constants';
-import { Chain, MoonChain } from '../../interfaces';
+import { MoonChain } from '../../interfaces';
 import { ExtrinsicPallet } from '../extrinsic.constants';
 import {
   getCreateV1V2Extrinsic,
@@ -8,44 +7,38 @@ import {
 } from '../polkadotXcm';
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
-export function xcmPallet<ChainKeys extends ChainKey>(chain: MoonChain) {
+export function xcmPallet(chain: MoonChain) {
   return {
-    limitedReserveTransferAssets: () =>
-      limitedReserveTransferAssets<ChainKeys>(chain),
+    limitedReserveTransferAssets: () => limitedReserveTransferAssets(chain),
   };
 }
 
-function limitedReserveTransferAssets<ChainKeys extends ChainKey>(
-  chain: MoonChain,
-) {
+function limitedReserveTransferAssets(chain: MoonChain) {
   return {
-    successEvent: (event: PolkadotXcmExtrinsicSuccessEvent) => ({
-      origin: (origin: Chain<ChainKeys>) => {
-        const createExtrinsic = getCreateV1V2Extrinsic(
-          PolkadotXcmExtrinsic.LimitedReserveTransferAssets,
-          event,
-          chain,
-          origin,
-          0,
-        );
+    successEvent: (event: PolkadotXcmExtrinsicSuccessEvent) => {
+      const createExtrinsic = getCreateV1V2Extrinsic(
+        PolkadotXcmExtrinsic.LimitedReserveTransferAssets,
+        event,
+        chain,
+        0,
+      );
 
-        return {
-          ...createExtrinsic((amount) => [
-            {
-              id: {
-                Concrete: {
-                  parents: 0,
-                  interior: 'Here',
-                },
-              },
-              fun: {
-                Fungible: amount,
+      return {
+        ...createExtrinsic((amount) => [
+          {
+            id: {
+              Concrete: {
+                parents: 0,
+                interior: 'Here',
               },
             },
-          ]),
-          pallet: ExtrinsicPallet.XcmPallet,
-        };
-      },
-    }),
+            fun: {
+              Fungible: amount,
+            },
+          },
+        ]),
+        pallet: ExtrinsicPallet.XcmPallet,
+      };
+    },
   };
 }


### PR DESCRIPTION
### Description

Version 0 of the MultiLocation type is being deprecated, so removed the `V0` extrinsic it from `polkadotXcm`. 
Modified `polkadotXcm` `V1` extrinsics to autodetect what `MultiLocation` versions are available in the origin chain and build the parameters accordingly.
Updated CSM deposit extrinsic from  `polkadotXcm` `V0` to `V1V2`

### Checklist

- [x] If this requires a documentation change, I have created a PR in [moonbeam-docs](https://github.com/PureStake/moonbeam-docs) repository.
- [x] If this requires it, I have updated the Readme
- [x] If necessary, I have updated the examples
- [x] I have verified if I need to create/update unit tests
- [x] I have verified if I need to create/update acceptance tests
- [x] If necessary, I have run acceptance tests on this branch in CI
