### PR TITLE
Support withdraw to chains with Ethereum accounts

### DIFF
--- a/packages/config/src/config/moonbase/assets/paring.ts
+++ b/packages/config/src/config/moonbase/assets/paring.ts
@@ -1,0 +1,37 @@
+import { AssetSymbol, ChainKey } from '../../../constants';
+import { PolkadotXcmExtrinsicSuccessEvent } from '../../../extrinsic';
+import {
+  assets,
+  balance,
+  chains,
+  extrinsic,
+  withdraw,
+} from '../moonbase.common';
+import { MoonbaseXcmConfig } from '../moonbase.interfaces';
+
+const asset = assets[AssetSymbol.PARING];
+const origin = chains[ChainKey.DarwiniaPangoro];
+
+export const PARING: MoonbaseXcmConfig = {
+  asset,
+  origin,
+  deposit: {
+    [origin.key]: {
+      source: origin,
+      balance: balance.system(),
+      extrinsic: extrinsic
+        .polkadotXcm()
+        .limitedReserveTransferAssets()
+        .successEvent(PolkadotXcmExtrinsicSuccessEvent.Attempted)
+        .V1V2()
+        .X1(),
+    },
+  },
+  withdraw: {
+    [origin.key]: withdraw.xTokens({
+      balance: balance.system(),
+      destination: origin,
+      feePerWeight: 1_000_000_000,
+    }),
+  },
+};

--- a/packages/config/src/config/moonbase/moonbase.assets.ts
+++ b/packages/config/src/config/moonbase/moonbase.assets.ts
@@ -8,6 +8,7 @@ export const MOONBASE_ASSETS = <const>[
   AssetSymbol.DEV,
   AssetSymbol.LIT,
   AssetSymbol.NEER,
+  AssetSymbol.PARING,
   AssetSymbol.TT1,
   AssetSymbol.UNIT,
 ];
@@ -39,10 +40,10 @@ export const MOONBASE_ASSETS_MAP: AssetsMap<MoonbaseAssets> = {
     erc20Id: '0xffffffff2754f0bdf7eb215503c69204ccd61c5d',
     originSymbol: AssetSymbol.NEER,
   },
-  [AssetSymbol.UNIT]: {
-    id: '42259045809535163221576417993425387648',
-    erc20Id: '0xffffffff1fcacbd218edc0eba20fc2308c778080',
-    originSymbol: AssetSymbol.UNIT,
+  [AssetSymbol.PARING]: {
+    id: '173481220575862801646329923366065693029',
+    erc20Id: '0xffffffff8283448b3cb519ca4732f2dddc6a6165',
+    originSymbol: AssetSymbol.PARING,
   },
   [AssetSymbol.TT1]: {
     id: '156305701417244550631956600137082963628',
@@ -51,5 +52,10 @@ export const MOONBASE_ASSETS_MAP: AssetsMap<MoonbaseAssets> = {
     foreignIds: {
       [ChainKey.StatemineAlphanet]: 2,
     },
+  },
+  [AssetSymbol.UNIT]: {
+    id: '42259045809535163221576417993425387648',
+    erc20Id: '0xffffffff1fcacbd218edc0eba20fc2308c778080',
+    originSymbol: AssetSymbol.UNIT,
   },
 };

--- a/packages/config/src/config/moonbase/moonbase.chains.ts
+++ b/packages/config/src/config/moonbase/moonbase.chains.ts
@@ -6,6 +6,7 @@ export const MOONBASE_CHAINS = <const>[
   ChainKey.AlphanetRelay,
   ChainKey.LitentryAlphanet,
   ChainKey.BitCountryPioneer,
+  ChainKey.DarwiniaPangoro,
   ChainKey.MoonbaseBeta,
   ChainKey.StatemineAlphanet,
   ChainKey.UniqueAlpha,
@@ -32,6 +33,16 @@ export const MOONBASE_CHAINS_MAP: ChainsMap<MoonbaseChains> = {
     ss58Format: 268,
     genesisHash:
       '0xb27da7332d3a229f0d5f2a83f711b3f74a70f22b68021e92c37817057de58e74',
+  },
+  [ChainKey.DarwiniaPangoro]: {
+    key: ChainKey.DarwiniaPangoro,
+    name: 'Pangoro',
+    ws: 'wss://pangoro-rpc.darwinia.network',
+    weight: 1_000_000_000,
+    parachainId: 2105,
+    ss58Format: 18,
+    genesisHash:
+      '0xaaa8b33b723b30b44e45e4e6c01936cc92e7559b4184fb0cee2853d55610fcbf',
   },
   [ChainKey.LitentryAlphanet]: {
     key: ChainKey.LitentryAlphanet,

--- a/packages/config/src/config/moonbase/moonbase.chains.ts
+++ b/packages/config/src/config/moonbase/moonbase.chains.ts
@@ -40,7 +40,7 @@ export const MOONBASE_CHAINS_MAP: ChainsMap<MoonbaseChains> = {
     ws: 'wss://pangoro-rpc.darwinia.network',
     weight: 1_000_000_000,
     parachainId: 2105,
-    ss58Format: 18,
+    usesEthereumAccounts: true,
     genesisHash:
       '0xaaa8b33b723b30b44e45e4e6c01936cc92e7559b4184fb0cee2853d55610fcbf',
   },

--- a/packages/config/src/config/moonbase/moonbase.ts
+++ b/packages/config/src/config/moonbase/moonbase.ts
@@ -6,6 +6,7 @@ import { BIT } from './assets/bit';
 import { DEV } from './assets/dev';
 import { LIT } from './assets/lit';
 import { NEER } from './assets/neer';
+import { PARING } from './assets/paring';
 import { TT1 } from './assets/tt1';
 import { UNIT } from './assets/unit';
 
@@ -15,6 +16,7 @@ export const MOONBASE_CONFIGS: MoonbaseXcmConfigs = {
   [AssetSymbol.DEV]: DEV,
   [AssetSymbol.LIT]: LIT,
   [AssetSymbol.NEER]: NEER,
+  [AssetSymbol.PARING]: PARING,
   [AssetSymbol.TT1]: TT1,
   [AssetSymbol.UNIT]: UNIT,
 };

--- a/packages/config/src/constants/assets.ts
+++ b/packages/config/src/constants/assets.ts
@@ -23,6 +23,7 @@ export enum AssetSymbol {
   MOVR = 'MOVR',
   NEER = 'NEER',
   PARA = 'PARA',
+  PARING = 'PARING',
   PHA = 'PHA',
   RING = 'RING',
   RMRK = 'RMRK',

--- a/packages/config/src/constants/chains.ts
+++ b/packages/config/src/constants/chains.ts
@@ -52,6 +52,7 @@ export enum ChainKey {
   Crab = 'Crab',
   CrustShadow = 'CrustShadow',
   Darwinia = 'Darwinia',
+  DarwiniaPangoro = 'DarwiniaPangoro',
   Integritee = 'Integritee',
   Interlay = 'Interlay',
   Karura = 'Karura',

--- a/packages/config/src/interfaces.ts
+++ b/packages/config/src/interfaces.ts
@@ -49,7 +49,8 @@ export interface Chain<ChainKeys extends ChainKey = ChainKey>
    * unitsPerSecond = weightPerSecond * baseExtrinsicCost / baseExtrinsicWeight
    */
   unitsPerSecond?: bigint;
-  ss58Format: number;
+  ss58Format?: number;
+  usesEthereumAccounts?: boolean;
   genesisHash: string;
 }
 

--- a/packages/config/src/withdraw/__snapshots__/withdraw.test.ts.snap
+++ b/packages/config/src/withdraw/__snapshots__/withdraw.test.ts.snap
@@ -1,10 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`withdraw xTokens eth account should get params with parachain id 1`] = `
+[
+  1,
+  [
+    "0x000000064",
+    "0x03ef46c7649270c912704fb09b75097f6e32208b8500",
+  ],
+]
+`;
+
+exports[`withdraw xTokens eth account should get params without parachain id 1`] = `
+[
+  1,
+  [
+    "0x03ef46c7649270c912704fb09b75097f6e32208b8500",
+  ],
+]
+`;
+
 exports[`withdraw xTokens should be correct withdraw config 1`] = `
 {
   "balance": "<BALANCE>",
   "destination": {
-    "parachainId": 1000,
+    "parachainId": 100,
   },
   "feePerWeight": 8,
   "getParams": [Function],
@@ -14,21 +33,21 @@ exports[`withdraw xTokens should be correct withdraw config 1`] = `
 }
 `;
 
-exports[`withdraw xTokens should get params with parachain id 1`] = `
+exports[`withdraw xTokens substrate account should get params with parachain id 1`] = `
 [
   1,
   [
-    "0x00000003e8",
-    "0x01ef46c7649270c912704fb09b75097f6e32208b8500",
+    "0x000000064",
+    "0x01c4db7bcb733e117c0b34ac96354b10d47e84a006b9e7e66a229d174e8ff2a06300",
   ],
 ]
 `;
 
-exports[`withdraw xTokens should get params without parachain id 1`] = `
+exports[`withdraw xTokens substrate account should get params without parachain id 1`] = `
 [
   1,
   [
-    "0x01ef46c7649270c912704fb09b75097f6e32208b8500",
+    "0x01c4db7bcb733e117c0b34ac96354b10d47e84a006b9e7e66a229d174e8ff2a06300",
   ],
 ]
 `;

--- a/packages/config/src/withdraw/withdraw.interfaces.ts
+++ b/packages/config/src/withdraw/withdraw.interfaces.ts
@@ -17,7 +17,7 @@ export interface WithdrawXTokensConfig<
   weight: number;
   getParams: (
     account: string,
-    isEthereumAccount: boolean | undefined,
+    usesEthereumAccounts: boolean | undefined,
   ) => WithdrawXTokensParams;
 }
 

--- a/packages/config/src/withdraw/withdraw.interfaces.ts
+++ b/packages/config/src/withdraw/withdraw.interfaces.ts
@@ -15,7 +15,10 @@ export interface WithdrawXTokensConfig<
   sourceMinBalance?: MinBalanceConfig;
   xcmFeeAsset?: WithdrawXcmFeeAsset<Symbols>;
   weight: number;
-  getParams: (account: string) => WithdrawXTokensParams;
+  getParams: (
+    account: string,
+    isEthereumAccount: boolean | undefined,
+  ) => WithdrawXTokensParams;
 }
 
 export type WithdrawXTokensParams = [

--- a/packages/config/src/withdraw/withdraw.test.ts
+++ b/packages/config/src/withdraw/withdraw.test.ts
@@ -1,32 +1,52 @@
 import { createWithdrawBuilder } from './withdraw';
 
 describe('withdraw', () => {
-  const account = '0xeF46c7649270C912704fB09B75097f6E32208b85';
   const withdraw = createWithdrawBuilder();
 
   describe('xTokens', () => {
     const cfg = withdraw.xTokens({
       balance: '<BALANCE>' as any,
-      destination: { parachainId: 1000 } as any,
+      destination: { parachainId: 100 } as any,
       feePerWeight: 8,
     });
 
     it('should be correct withdraw config', () => {
       expect(cfg).toMatchSnapshot();
     });
+    describe('substrate account', () => {
+      const account = '5GWpSdqkkKGZmdKQ9nkSF7TmHp6JWt28BMGQNuG4MXtSvq3e';
 
-    it('should get params with parachain id', () => {
-      expect(cfg.getParams(account)).toMatchSnapshot();
-    });
-
-    it('should get params without parachain id', () => {
-      const cfg2 = withdraw.xTokens({
-        balance: '<BALANCE>' as any,
-        destination: {} as any,
-        feePerWeight: 8,
+      it('should get params with parachain id', () => {
+        expect(cfg.getParams(account, false)).toMatchSnapshot();
       });
 
-      expect(cfg2.getParams(account)).toMatchSnapshot();
+      it('should get params without parachain id', () => {
+        const cfg2 = withdraw.xTokens({
+          balance: '<BALANCE>' as any,
+          destination: {} as any,
+          feePerWeight: 8,
+        });
+
+        expect(cfg2.getParams(account, false)).toMatchSnapshot();
+      });
+    });
+
+    describe('eth account', () => {
+      const account = '0xeF46c7649270C912704fB09B75097f6E32208b85';
+
+      it('should get params with parachain id', () => {
+        expect(cfg.getParams(account, true)).toMatchSnapshot();
+      });
+
+      it('should get params without parachain id', () => {
+        const cfg2 = withdraw.xTokens({
+          balance: '<BALANCE>' as any,
+          destination: {} as any,
+          feePerWeight: 8,
+        });
+
+        expect(cfg2.getParams(account, true)).toMatchSnapshot();
+      });
     });
   });
 });

--- a/packages/config/src/withdraw/withdraw.ts
+++ b/packages/config/src/withdraw/withdraw.ts
@@ -31,9 +31,18 @@ function xTokens<Symbols extends AssetSymbol = AssetSymbol>({
     sourceMinBalance,
     xcmFeeAsset,
     weight,
-    getParams: (account: string) => {
+    getParams: (account: string, usesEthereumAccounts = false) => {
       const { parachainId } = destination;
-      const acc = `0x01${u8aToHex(decodeAddress(account), -1, false)}00`;
+      // 01: AccountId32
+      // 03: AccountKey20
+      // https://docs.moonbeam.network/builders/interoperability/xcm/xc20/xtokens/#building-the-precompile-multilocation
+      const accountType = usesEthereumAccounts ? '03' : '01';
+
+      const acc = `0x${accountType}${u8aToHex(
+        decodeAddress(account),
+        -1,
+        false,
+      )}00`;
 
       return [
         1,

--- a/packages/sdk/src/contracts/XTokensContract/XTokensContract.ts
+++ b/packages/sdk/src/contracts/XTokensContract/XTokensContract.ts
@@ -28,6 +28,8 @@ export class XTokensContract<Symbols extends AssetSymbol = AssetSymbol> {
     minAmount: bigint,
   ): Promise<TransactionResponse> {
     const { usesEthereumAccounts } = config.destination;
+    const params = config.getParams(account, usesEthereumAccounts);
+
     if (config.xcmFeeAsset) {
       return this.#contract.transferMultiCurrencies(
         [
@@ -35,14 +37,15 @@ export class XTokensContract<Symbols extends AssetSymbol = AssetSymbol> {
           [asset.erc20Id, amount],
         ],
         0,
-        config.getParams(account, usesEthereumAccounts),
+        params,
         config.weight,
       );
     }
+
     return this.#contract.transfer(
       asset.erc20Id,
       amount,
-      config.getParams(account, usesEthereumAccounts),
+      params,
       config.weight,
     );
   }

--- a/packages/sdk/src/contracts/XTokensContract/XTokensContract.ts
+++ b/packages/sdk/src/contracts/XTokensContract/XTokensContract.ts
@@ -27,6 +27,7 @@ export class XTokensContract<Symbols extends AssetSymbol = AssetSymbol> {
     config: WithdrawXTokensConfig<Symbols>,
     minAmount: bigint,
   ): Promise<TransactionResponse> {
+    const { usesEthereumAccounts } = config.destination;
     if (config.xcmFeeAsset) {
       return this.#contract.transferMultiCurrencies(
         [
@@ -34,14 +35,14 @@ export class XTokensContract<Symbols extends AssetSymbol = AssetSymbol> {
           [asset.erc20Id, amount],
         ],
         0,
-        config.getParams(account),
+        config.getParams(account, usesEthereumAccounts),
         config.weight,
       );
     }
     return this.#contract.transfer(
       asset.erc20Id,
       amount,
-      config.getParams(account),
+      config.getParams(account, usesEthereumAccounts),
       config.weight,
     );
   }
@@ -56,7 +57,7 @@ export class XTokensContract<Symbols extends AssetSymbol = AssetSymbol> {
       await this.#contract.estimateGas.transfer(
         asset.erc20Id,
         amount,
-        config.getParams(account),
+        config.getParams(account, config.destination.usesEthereumAccounts),
         config.weight,
       )
     ).toBigInt();


### PR DESCRIPTION
### Description

Darwinia has started migrating to ethereum type accounts, making it incompatible with the SDKs withdrawals. This PR adds a new `usesEthereumAccounts` flag to `Chain` configs. Withdraw will now take that flag into account when building the withdraw contract call params data.
Pangoro Alphanet temporarily added to test.

### Checklist

- [x] If this requires a documentation change, I have created a PR in [moonbeam-docs](https://github.com/PureStake/moonbeam-docs) repository.
- [x] If this requires it, I have updated the Readme
- [x] If necessary, I have updated the examples
- [x] I have verified if I need to create/update unit tests
- [x] I have verified if I need to create/update acceptance tests
- [x] If necessary, I have run acceptance tests on this branch in CI
