### PR TITLE
use toFixed to prevent transformins scientific notation to bigint error

### DIFF
--- a/packages/sdk/src/getTransferData/getTransferData.ts
+++ b/packages/sdk/src/getTransferData/getTransferData.ts
@@ -60,7 +60,7 @@ export async function getTransferData({
       );
 
       return source.balance.copyWith({
-        amount: result.lt(0) ? 0n : BigInt(result.toString()),
+        amount: result.lt(0) ? 0n : BigInt(result.toFixed()),
       });
     },
     /**

--- a/packages/utils/src/numbers/decimals.ts
+++ b/packages/utils/src/numbers/decimals.ts
@@ -12,7 +12,7 @@ export function toDecimal(
   const divisor = Big(10).pow(decimals);
   const result = dividend.div(divisor).round(maxDecimal, roundType);
 
-  return result.toString();
+  return result.toFixed();
 }
 
 export function toBigInt(


### PR DESCRIPTION
### Description

By using `toString`, numbers with order of magnitude bigger than 21 are shown in scientific notation. By converting to bigint, we get an error 
![image](https://github.com/PureStake/xcm-sdk/assets/93129175/37251e1c-28e9-4c07-8c81-ac1f20e8d347)

Using `toFixed` will ensure that this doesn't happen

### Checklist

- [x] If this requires a documentation change, I have created a PR in [moonbeam-docs](https://github.com/PureStake/moonbeam-docs) repository.
- [x] If this requires it, I have updated the Readme
- [x] If necessary, I have updated the examples
- [x] I have verified if I need to create/update unit tests
- [x] I have verified if I need to create/update acceptance tests
- [x] If necessary, I have run acceptance tests on this branch in CI
