### PR TITLE
HydraDX ERC20 integrations - use ERC20 decimals fix

### DIFF
--- a/.changeset/spotty-turtles-buy.md
+++ b/.changeset/spotty-turtles-buy.md
@@ -1,0 +1,6 @@
+---
+'@moonbeam-network/xcm-config': patch
+'@moonbeam-network/xcm-sdk': patch
+---
+
+Integrate Wormhole ERC20 tokens

--- a/packages/config/src/assets.ts
+++ b/packages/config/src/assets.ts
@@ -200,14 +200,14 @@ export const unit = new Asset({
   originSymbol: 'Unit',
 });
 
+export const usdc = new Asset({
+  key: 'usdc',
+  originSymbol: 'USDC',
+});
+
 export const usdt = new Asset({
   key: 'usdt',
   originSymbol: 'USDT',
-});
-
-export const xrt = new Asset({
-  key: 'xrt',
-  originSymbol: 'XRT',
 });
 
 export const wbtc = new Asset({
@@ -225,9 +225,9 @@ export const wftm = new Asset({
   originSymbol: 'wFTM',
 });
 
-export const whusdc = new Asset({
-  key: 'whusdc',
-  originSymbol: 'whUSDC',
+export const xrt = new Asset({
+  key: 'xrt',
+  originSymbol: 'XRT',
 });
 
 export const assetsList: Asset[] = [
@@ -270,12 +270,12 @@ export const assetsList: Asset[] = [
   tt1,
   tur,
   unit,
+  usdc,
   usdt,
   xrt,
   wbtc,
   weth,
   wftm,
-  whusdc,
 ];
 
 export const assetsMap = new Map<string, Asset>(

--- a/packages/config/src/assets.ts
+++ b/packages/config/src/assets.ts
@@ -70,6 +70,11 @@ export const eqd = new Asset({
   originSymbol: 'EQD',
 });
 
+export const dai = new Asset({
+  key: 'dai',
+  originSymbol: 'DAI',
+});
+
 export const glmr = new Asset({
   key: 'glmr',
   originSymbol: 'GLMR',
@@ -195,6 +200,11 @@ export const unit = new Asset({
   originSymbol: 'Unit',
 });
 
+export const usdc = new Asset({
+  key: 'usdc',
+  originSymbol: 'USDC',
+});
+
 export const usdt = new Asset({
   key: 'usdt',
   originSymbol: 'USDT',
@@ -203,6 +213,21 @@ export const usdt = new Asset({
 export const xrt = new Asset({
   key: 'xrt',
   originSymbol: 'XRT',
+});
+
+export const wbtc = new Asset({
+  key: 'wbtc',
+  originSymbol: 'WBTC',
+});
+
+export const weth = new Asset({
+  key: 'weth',
+  originSymbol: 'WETH',
+});
+
+export const wftm = new Asset({
+  key: 'wftm',
+  originSymbol: 'wFTM',
 });
 
 export const assetsList: Asset[] = [
@@ -215,6 +240,7 @@ export const assetsList: Asset[] = [
   cfg,
   crab,
   csm,
+  dai,
   dev,
   dot,
   eq,
@@ -244,8 +270,12 @@ export const assetsList: Asset[] = [
   tt1,
   tur,
   unit,
+  usdc,
   usdt,
   xrt,
+  wbtc,
+  weth,
+  wftm,
 ];
 
 export const assetsMap = new Map<string, Asset>(

--- a/packages/config/src/assets.ts
+++ b/packages/config/src/assets.ts
@@ -200,11 +200,6 @@ export const unit = new Asset({
   originSymbol: 'Unit',
 });
 
-export const usdc = new Asset({
-  key: 'usdc',
-  originSymbol: 'USDC',
-});
-
 export const usdt = new Asset({
   key: 'usdt',
   originSymbol: 'USDT',
@@ -228,6 +223,11 @@ export const weth = new Asset({
 export const wftm = new Asset({
   key: 'wftm',
   originSymbol: 'wFTM',
+});
+
+export const whusdc = new Asset({
+  key: 'whusdc',
+  originSymbol: 'whUSDC',
 });
 
 export const assetsList: Asset[] = [
@@ -270,12 +270,12 @@ export const assetsList: Asset[] = [
   tt1,
   tur,
   unit,
-  usdc,
   usdt,
   xrt,
   wbtc,
   weth,
   wftm,
+  whusdc,
 ];
 
 export const assetsMap = new Map<string, Asset>(

--- a/packages/config/src/chains.ts
+++ b/packages/config/src/chains.ts
@@ -45,10 +45,10 @@ import {
   tt1,
   tur,
   unit,
+  usdc,
   usdt,
   wbtc,
   weth,
-  whusdc,
   xrt,
 } from './assets';
 
@@ -391,7 +391,7 @@ export const hydraDX = new Parachain({
       id: 18,
     },
     {
-      asset: whusdc,
+      asset: usdc,
       id: 21,
     },
     {
@@ -792,7 +792,7 @@ export const moonbeam = new EvmParachain({
       id: '125699734534028342599692732320197985871',
     },
     {
-      asset: whusdc,
+      asset: usdc,
       id: '0x931715FEE2d06333043d11F658C8CE934aC61D0c',
       metadataId: 0, // no metadata for ERC20 tokens
     },

--- a/packages/config/src/chains.ts
+++ b/packages/config/src/chains.ts
@@ -741,11 +741,11 @@ export const moonbeam = new EvmParachain({
       asset: cfg,
       id: '91372035960551235635465443179559840483',
     },
-    {
-      asset: dai,
-      id: '0x06e605775296e851FF43b4dAa541Bb0984E9D6fD',
-      metadataId: 0, // no metadata for ERC20 tokens
-    },
+    // {
+    //   asset: dai,
+    //   id: '0x06e605775296e851FF43b4dAa541Bb0984E9D6fD',
+    //   metadataId: 0, // no metadata for ERC20 tokens
+    // },
     {
       asset: dot,
       id: '42259045809535163221576417993425387648',

--- a/packages/config/src/chains.ts
+++ b/packages/config/src/chains.ts
@@ -15,6 +15,7 @@ import {
   cfg,
   crab,
   csm,
+  dai,
   dev,
   dot,
   eq,
@@ -44,7 +45,10 @@ import {
   tt1,
   tur,
   unit,
+  usdc,
   usdt,
+  wbtc,
+  weth,
   xrt,
 } from './assets';
 
@@ -381,6 +385,22 @@ export const hydraDX = new Parachain({
     {
       asset: glmr,
       id: 16,
+    },
+    {
+      asset: dai,
+      id: 18,
+    },
+    {
+      asset: usdc,
+      id: 21,
+    },
+    {
+      asset: wbtc,
+      id: 19,
+    },
+    {
+      asset: weth,
+      id: 20,
     },
   ],
   ecosystem: Ecosystem.Polkadot,
@@ -722,6 +742,11 @@ export const moonbeam = new EvmParachain({
       id: '91372035960551235635465443179559840483',
     },
     {
+      asset: dai,
+      id: '0x06e605775296e851FF43b4dAa541Bb0984E9D6fD',
+      metadataId: 0, // no metadata for ERC20 tokens
+    },
+    {
       asset: dot,
       id: '42259045809535163221576417993425387648',
     },
@@ -767,8 +792,23 @@ export const moonbeam = new EvmParachain({
       id: '125699734534028342599692732320197985871',
     },
     {
+      asset: usdc,
+      id: '0x931715FEE2d06333043d11F658C8CE934aC61D0c',
+      metadataId: 0, // no metadata for ERC20 tokens
+    },
+    {
       asset: usdt,
       id: '311091173110107856861649819128533077277',
+    },
+    {
+      asset: wbtc,
+      id: '0xE57eBd2d67B462E9926e04a8e33f01cD0D64346D',
+      metadataId: 0, // no metadata for ERC20 tokens
+    },
+    {
+      asset: weth,
+      id: '0xab3f0245B83feB11d15AAffeFD7AD465a59817eD',
+      metadataId: 0, // no metadata for ERC20 tokens
     },
   ],
   ecosystem: Ecosystem.Polkadot,

--- a/packages/config/src/chains.ts
+++ b/packages/config/src/chains.ts
@@ -45,10 +45,10 @@ import {
   tt1,
   tur,
   unit,
-  usdc,
   usdt,
   wbtc,
   weth,
+  whusdc,
   xrt,
 } from './assets';
 
@@ -391,7 +391,7 @@ export const hydraDX = new Parachain({
       id: 18,
     },
     {
-      asset: usdc,
+      asset: whusdc,
       id: 21,
     },
     {
@@ -792,7 +792,7 @@ export const moonbeam = new EvmParachain({
       id: '125699734534028342599692732320197985871',
     },
     {
-      asset: usdc,
+      asset: whusdc,
       id: '0x931715FEE2d06333043d11F658C8CE934aC61D0c',
       metadataId: 0, // no metadata for ERC20 tokens
     },

--- a/packages/config/src/configs/hydraDX.ts
+++ b/packages/config/src/configs/hydraDX.ts
@@ -3,7 +3,7 @@ import {
   ExtrinsicBuilder,
   FeeBuilder,
 } from '@moonbeam-network/xcm-builder';
-import { glmr, hdx, usdc, wbtc, weth } from '../assets';
+import { glmr, hdx, wbtc, weth, whusdc } from '../assets';
 import { hydraDX, moonbeam } from '../chains';
 import { AssetConfig } from '../types/AssetConfig';
 import { ChainConfig } from '../types/ChainConfig';
@@ -46,20 +46,6 @@ export const hydraDxConfig = new ChainConfig({
     //   },
     // }),
     new AssetConfig({
-      asset: usdc,
-      balance: BalanceBuilder().substrate().tokens().accounts(),
-      destination: moonbeam,
-      destinationFee: {
-        amount: 0.04,
-        asset: glmr,
-      },
-      extrinsic: ExtrinsicBuilder().xTokens().transferMultiCurrencies(),
-      fee: {
-        asset: hdx,
-        balance: BalanceBuilder().substrate().system().account(),
-      },
-    }),
-    new AssetConfig({
       asset: wbtc,
       balance: BalanceBuilder().substrate().tokens().accounts(),
       destination: moonbeam,
@@ -75,6 +61,20 @@ export const hydraDxConfig = new ChainConfig({
     }),
     new AssetConfig({
       asset: weth,
+      balance: BalanceBuilder().substrate().tokens().accounts(),
+      destination: moonbeam,
+      destinationFee: {
+        amount: 0.04,
+        asset: glmr,
+      },
+      extrinsic: ExtrinsicBuilder().xTokens().transferMultiCurrencies(),
+      fee: {
+        asset: hdx,
+        balance: BalanceBuilder().substrate().system().account(),
+      },
+    }),
+    new AssetConfig({
+      asset: whusdc,
       balance: BalanceBuilder().substrate().tokens().accounts(),
       destination: moonbeam,
       destinationFee: {

--- a/packages/config/src/configs/hydraDX.ts
+++ b/packages/config/src/configs/hydraDX.ts
@@ -3,7 +3,7 @@ import {
   ExtrinsicBuilder,
   FeeBuilder,
 } from '@moonbeam-network/xcm-builder';
-import { glmr, hdx, wbtc, weth, whusdc } from '../assets';
+import { glmr, hdx, usdc, wbtc, weth } from '../assets';
 import { hydraDX, moonbeam } from '../chains';
 import { AssetConfig } from '../types/AssetConfig';
 import { ChainConfig } from '../types/ChainConfig';
@@ -46,6 +46,20 @@ export const hydraDxConfig = new ChainConfig({
     //   },
     // }),
     new AssetConfig({
+      asset: usdc,
+      balance: BalanceBuilder().substrate().tokens().accounts(),
+      destination: moonbeam,
+      destinationFee: {
+        amount: 0.04,
+        asset: glmr,
+      },
+      extrinsic: ExtrinsicBuilder().xTokens().transferMultiCurrencies(),
+      fee: {
+        asset: hdx,
+        balance: BalanceBuilder().substrate().system().account(),
+      },
+    }),
+    new AssetConfig({
       asset: wbtc,
       balance: BalanceBuilder().substrate().tokens().accounts(),
       destination: moonbeam,
@@ -61,20 +75,6 @@ export const hydraDxConfig = new ChainConfig({
     }),
     new AssetConfig({
       asset: weth,
-      balance: BalanceBuilder().substrate().tokens().accounts(),
-      destination: moonbeam,
-      destinationFee: {
-        amount: 0.04,
-        asset: glmr,
-      },
-      extrinsic: ExtrinsicBuilder().xTokens().transferMultiCurrencies(),
-      fee: {
-        asset: hdx,
-        balance: BalanceBuilder().substrate().system().account(),
-      },
-    }),
-    new AssetConfig({
-      asset: whusdc,
       balance: BalanceBuilder().substrate().tokens().accounts(),
       destination: moonbeam,
       destinationFee: {

--- a/packages/config/src/configs/hydraDX.ts
+++ b/packages/config/src/configs/hydraDX.ts
@@ -3,7 +3,7 @@ import {
   ExtrinsicBuilder,
   FeeBuilder,
 } from '@moonbeam-network/xcm-builder';
-import { glmr, hdx } from '../assets';
+import { glmr, hdx, usdc, wbtc, weth } from '../assets';
 import { hydraDX, moonbeam } from '../chains';
 import { AssetConfig } from '../types/AssetConfig';
 import { ChainConfig } from '../types/ChainConfig';
@@ -29,6 +29,63 @@ export const hydraDxConfig = new ChainConfig({
         asset: glmr,
       },
       extrinsic: ExtrinsicBuilder().xTokens().transfer(),
+    }),
+    // TODO pending tests
+    // new AssetConfig({
+    //   asset: dai,
+    //   balance: BalanceBuilder().substrate().tokens().accounts(),
+    //   destination: moonbeam,
+    //   destinationFee: {
+    //     amount: 0.04,
+    //     asset: glmr,
+    //   },
+    //   extrinsic: ExtrinsicBuilder().xTokens().transferMultiCurrencies(),
+    //   fee: {
+    //     asset: hdx,
+    //     balance: BalanceBuilder().substrate().system().account(),
+    //   },
+    // }),
+    new AssetConfig({
+      asset: usdc,
+      balance: BalanceBuilder().substrate().tokens().accounts(),
+      destination: moonbeam,
+      destinationFee: {
+        amount: 0.04,
+        asset: glmr,
+      },
+      extrinsic: ExtrinsicBuilder().xTokens().transferMultiCurrencies(),
+      fee: {
+        asset: hdx,
+        balance: BalanceBuilder().substrate().system().account(),
+      },
+    }),
+    new AssetConfig({
+      asset: wbtc,
+      balance: BalanceBuilder().substrate().tokens().accounts(),
+      destination: moonbeam,
+      destinationFee: {
+        amount: 0.04,
+        asset: glmr,
+      },
+      extrinsic: ExtrinsicBuilder().xTokens().transferMultiCurrencies(),
+      fee: {
+        asset: hdx,
+        balance: BalanceBuilder().substrate().system().account(),
+      },
+    }),
+    new AssetConfig({
+      asset: weth,
+      balance: BalanceBuilder().substrate().tokens().accounts(),
+      destination: moonbeam,
+      destinationFee: {
+        amount: 0.04,
+        asset: glmr,
+      },
+      extrinsic: ExtrinsicBuilder().xTokens().transferMultiCurrencies(),
+      fee: {
+        asset: hdx,
+        balance: BalanceBuilder().substrate().system().account(),
+      },
     }),
   ],
   chain: hydraDX,

--- a/packages/config/src/configs/moonbeam.ts
+++ b/packages/config/src/configs/moonbeam.ts
@@ -16,10 +16,10 @@ import {
   para,
   pha,
   ring,
-  usdc,
   usdt,
   wbtc,
   weth,
+  whusdc,
 } from '../assets';
 import {
   acala,
@@ -352,20 +352,6 @@ export const moonbeamConfig = new ChainConfig({
     //   },
     // }),
     new AssetConfig({
-      asset: usdc,
-      balance: BalanceBuilder().evm().erc20(),
-      contract: ContractBuilder().Xtokens().transfer(),
-      destination: hydraDX,
-      destinationFee: {
-        amount: 0.004,
-        asset: usdc,
-      },
-      fee: {
-        asset: glmr,
-        balance: BalanceBuilder().substrate().system().account(),
-      },
-    }),
-    new AssetConfig({
       asset: wbtc,
       balance: BalanceBuilder().evm().erc20(),
       contract: ContractBuilder().Xtokens().transfer(),
@@ -387,6 +373,20 @@ export const moonbeamConfig = new ChainConfig({
       destinationFee: {
         amount: 0.000002,
         asset: weth,
+      },
+      fee: {
+        asset: glmr,
+        balance: BalanceBuilder().substrate().system().account(),
+      },
+    }),
+    new AssetConfig({
+      asset: whusdc,
+      balance: BalanceBuilder().evm().erc20(),
+      contract: ContractBuilder().Xtokens().transfer(),
+      destination: hydraDX,
+      destinationFee: {
+        amount: 0.004,
+        asset: whusdc,
       },
       fee: {
         asset: glmr,

--- a/packages/config/src/configs/moonbeam.ts
+++ b/packages/config/src/configs/moonbeam.ts
@@ -16,10 +16,10 @@ import {
   para,
   pha,
   ring,
+  usdc,
   usdt,
   wbtc,
   weth,
-  whusdc,
 } from '../assets';
 import {
   acala,
@@ -352,6 +352,20 @@ export const moonbeamConfig = new ChainConfig({
     //   },
     // }),
     new AssetConfig({
+      asset: usdc,
+      balance: BalanceBuilder().evm().erc20(),
+      contract: ContractBuilder().Xtokens().transfer(),
+      destination: hydraDX,
+      destinationFee: {
+        amount: 0.004,
+        asset: usdc,
+      },
+      fee: {
+        asset: glmr,
+        balance: BalanceBuilder().substrate().system().account(),
+      },
+    }),
+    new AssetConfig({
       asset: wbtc,
       balance: BalanceBuilder().evm().erc20(),
       contract: ContractBuilder().Xtokens().transfer(),
@@ -373,20 +387,6 @@ export const moonbeamConfig = new ChainConfig({
       destinationFee: {
         amount: 0.000002,
         asset: weth,
-      },
-      fee: {
-        asset: glmr,
-        balance: BalanceBuilder().substrate().system().account(),
-      },
-    }),
-    new AssetConfig({
-      asset: whusdc,
-      balance: BalanceBuilder().evm().erc20(),
-      contract: ContractBuilder().Xtokens().transfer(),
-      destination: hydraDX,
-      destinationFee: {
-        amount: 0.004,
-        asset: whusdc,
       },
       fee: {
         asset: glmr,

--- a/packages/config/src/configs/moonbeam.ts
+++ b/packages/config/src/configs/moonbeam.ts
@@ -16,7 +16,10 @@ import {
   para,
   pha,
   ring,
+  usdc,
   usdt,
+  wbtc,
+  weth,
 } from '../assets';
 import {
   acala,
@@ -327,6 +330,63 @@ export const moonbeamConfig = new ChainConfig({
       destinationFee: {
         amount: 0.6,
         asset: hdx,
+      },
+      fee: {
+        asset: glmr,
+        balance: BalanceBuilder().substrate().system().account(),
+      },
+    }),
+    // TODO pending tests
+    // new AssetConfig({
+    //   asset: dai,
+    //   balance: BalanceBuilder().evm().erc20(),
+    //   contract: ContractBuilder().Xtokens().transfer(),
+    //   destination: hydraDX,
+    //   destinationFee: {
+    //     amount: 0.0002, // TODO
+    //     asset: glmr,
+    //   },
+    //   fee: {
+    //     asset: glmr,
+    //     balance: BalanceBuilder().substrate().system().account(),
+    //   },
+    // }),
+    new AssetConfig({
+      asset: usdc,
+      balance: BalanceBuilder().evm().erc20(),
+      contract: ContractBuilder().Xtokens().transfer(),
+      destination: hydraDX,
+      destinationFee: {
+        amount: 0.004,
+        asset: usdc,
+      },
+      fee: {
+        asset: glmr,
+        balance: BalanceBuilder().substrate().system().account(),
+      },
+    }),
+    new AssetConfig({
+      asset: wbtc,
+      balance: BalanceBuilder().evm().erc20(),
+      contract: ContractBuilder().Xtokens().transfer(),
+      destination: hydraDX,
+      destinationFee: {
+        amount: 0.0000001,
+        asset: wbtc,
+      },
+      fee: {
+        asset: glmr,
+        balance: BalanceBuilder().substrate().system().account(),
+      },
+    }),
+    new AssetConfig({
+      asset: weth,
+      balance: BalanceBuilder().evm().erc20(),
+      contract: ContractBuilder().Xtokens().transfer(),
+      destination: hydraDX,
+      destinationFee: {
+        amount: 0.000002,
+        asset: weth,
       },
       fee: {
         asset: glmr,

--- a/packages/sdk/src/contract/contract.interfaces.ts
+++ b/packages/sdk/src/contract/contract.interfaces.ts
@@ -11,4 +11,5 @@ export interface TransferContractInterface extends BaseContractInterface {
 
 export interface BalanceContractInterface extends BaseContractInterface {
   getBalance(): Promise<bigint>;
+  getDecimals(): Promise<number>;
 }

--- a/packages/sdk/src/contract/contracts/Erc20/Erc20.ts
+++ b/packages/sdk/src/contract/contracts/Erc20/Erc20.ts
@@ -25,4 +25,10 @@ export class Erc20 implements BalanceContractInterface {
 
     return balance.toBigInt();
   }
+
+  async getDecimals(): Promise<number> {
+    const decimals = await this.#contract.decimals();
+
+    return decimals;
+  }
 }

--- a/packages/sdk/src/getTransferData/getDestinationData.ts
+++ b/packages/sdk/src/getTransferData/getDestinationData.ts
@@ -6,7 +6,7 @@ import { toBigInt } from '@moonbeam-network/xcm-utils';
 import { Signer as EthersSigner } from 'ethers';
 import { PolkadotService } from '../polkadot';
 import { DestinationChainTransferData } from '../sdk.interfaces';
-import { getBalance, getMin } from './getTransferData.utils';
+import { getBalance, getDecimals, getMin } from './getTransferData.utils';
 
 export interface GetDestinationDataParams {
   transferConfig: TransferConfig;
@@ -25,9 +25,15 @@ export async function getDestinationData({
     asset,
     destination: { chain, config },
   } = transferConfig;
+
   const zeroAmount = AssetAmount.fromAsset(asset, {
     amount: 0n,
-    decimals: await polkadot.getAssetDecimals(asset),
+    decimals: await getDecimals({
+      address: destinationAddress,
+      config,
+      ethersSigner,
+      polkadot,
+    }),
   });
 
   const balance = await getBalance({

--- a/packages/sdk/src/getTransferData/getSourceData.ts
+++ b/packages/sdk/src/getTransferData/getSourceData.ts
@@ -12,7 +12,7 @@ import { Signer as EthersSigner } from 'ethers';
 import { TransferContractInterface, createContract } from '../contract';
 import { PolkadotService } from '../polkadot';
 import { SourceChainTransferData } from '../sdk.interfaces';
-import { getBalance, getMin } from './getTransferData.utils';
+import { getBalance, getDecimals, getMin } from './getTransferData.utils';
 
 export interface GetSourceDataParams {
   transferConfig: TransferConfig;
@@ -38,12 +38,23 @@ export async function getSourceData({
   } = transferConfig;
   const zeroAmount = AssetAmount.fromAsset(asset, {
     amount: 0n,
-    decimals: await polkadot.getAssetDecimals(asset),
+    decimals: await getDecimals({
+      address: destinationAddress,
+      config,
+      ethersSigner,
+      polkadot,
+    }),
   });
   const zeroFeeAmount = config.fee?.asset
     ? AssetAmount.fromAsset(config.fee.asset, {
         amount: 0n,
-        decimals: await polkadot.getAssetDecimals(config.fee.asset),
+        decimals: await getDecimals({
+          address: destinationAddress,
+          asset: config.fee.asset,
+          config,
+          ethersSigner,
+          polkadot,
+        }),
       })
     : zeroAmount;
 

--- a/packages/sdk/src/getTransferData/getTransferData.utils.ts
+++ b/packages/sdk/src/getTransferData/getTransferData.utils.ts
@@ -1,5 +1,6 @@
 import { CallType, SubstrateQueryConfig } from '@moonbeam-network/xcm-builder';
 import { AssetConfig } from '@moonbeam-network/xcm-config';
+import { Asset } from '@moonbeam-network/xcm-types';
 import { toBigInt } from '@moonbeam-network/xcm-utils';
 import { Signer as EthersSigner } from 'ethers';
 import { BalanceContractInterface, createContract } from '../contract';
@@ -10,6 +11,7 @@ export interface GetFeeBalancesParams {
   config: AssetConfig;
   ethersSigner: EthersSigner;
   polkadot: PolkadotService;
+  asset?: Asset;
 }
 
 export async function getBalance({
@@ -33,6 +35,30 @@ export async function getBalance({
   ) as BalanceContractInterface;
 
   return contract.getBalance();
+}
+
+export async function getDecimals({
+  address,
+  asset,
+  config,
+  ethersSigner,
+  polkadot,
+}: GetFeeBalancesParams) {
+  const cfg = config.balance.build({
+    address,
+    asset: polkadot.chain.getBalanceAssetId(asset || config.asset),
+  });
+
+  if (cfg.type === CallType.Substrate) {
+    return polkadot.getAssetDecimals(asset || config.asset);
+  }
+
+  const contract = createContract(
+    cfg,
+    ethersSigner,
+  ) as BalanceContractInterface;
+
+  return contract.getDecimals();
 }
 
 export async function getMin(config: AssetConfig, polkadot: PolkadotService) {


### PR DESCRIPTION
### Description

Integrate ERC20 transfers between HydraDX and Moonbeam
- WBTC
- WETH
- USDC
- DAI (commented out, pending tests)

Adapt the decimals fetching for ERC20s

### Checklist

- [x] If this requires a documentation change, I have created a PR in [moonbeam-docs](https://github.com/PureStake/moonbeam-docs) repository.
- [x] If this requires it, I have updated the Readme
- [x] If necessary, I have updated the examples
- [x] I have verified if I need to create/update unit tests
- [x] I have verified if I need to create/update acceptance tests
- [x] If necessary, I have run acceptance tests on this branch in CI
