### PR TITLE
revert change for getting decimals in destination fees, due to an error

### DIFF
--- a/.changeset/quiet-hotels-exist.md
+++ b/.changeset/quiet-hotels-exist.md
@@ -1,0 +1,6 @@
+---
+'@moonbeam-network/xcm-config': patch
+'@moonbeam-network/xcm-sdk': patch
+---
+
+Revert decimals change in destination fee

--- a/packages/config/src/chains.ts
+++ b/packages/config/src/chains.ts
@@ -182,7 +182,7 @@ export const bifrostKusama = new Parachain({
   name: 'Bifrost',
   parachainId: 2001,
   ss58Format: 6,
-  ws: 'wss://bifrost-rpc.liebi.com/ws',
+  ws: 'wss://us.bifrost-rpc.liebi.com/ws',
 });
 
 export const bifrostPolkadot = new Parachain({

--- a/packages/config/src/configs/bifrostPolkadot.ts
+++ b/packages/config/src/configs/bifrostPolkadot.ts
@@ -59,11 +59,11 @@ export const bifrostPolkadotConfig = new ChainConfig({
       balance: BalanceBuilder().substrate().tokens().accounts(),
       destination: moonbeam,
       destinationFee: {
-        amount: 0.01,
-        asset: vdot,
-        balance: BalanceBuilder().substrate().tokens().accounts(),
+        amount: 0.2,
+        asset: bnc,
+        balance: BalanceBuilder().substrate().system().account(),
       },
-      extrinsic: ExtrinsicBuilder().xTokens().transfer(),
+      extrinsic: ExtrinsicBuilder().xTokens().transferMultiCurrencies(),
       fee: {
         asset: bnc,
         balance: BalanceBuilder().substrate().system().account(),

--- a/packages/sdk/src/getTransferData/getDestinationData.ts
+++ b/packages/sdk/src/getTransferData/getDestinationData.ts
@@ -71,19 +71,12 @@ export interface GetFeeParams {
 }
 
 export async function getFee({
-  address,
   config,
-  evmSigner,
   polkadot,
 }: GetFeeParams): Promise<AssetAmount> {
   const { amount, asset } = config.source.config.destinationFee;
-  const decimals = await getDecimals({
-    address,
-    asset,
-    config: config.destination.config,
-    evmSigner,
-    polkadot,
-  });
+  // TODO we have to consider correctly here when an asset is ERC20 to get it from contract
+  const decimals = await polkadot.getAssetDecimals(asset);
   const zeroAmount = AssetAmount.fromAsset(asset, {
     amount: 0n,
     decimals,


### PR DESCRIPTION
### Description

Due to an error in uncontrolled cases, we revert the change that allowed to pay for fees in destination with an ERC20 by fetching decimals from contract

### Checklist

- [x] If this requires a documentation change, I have created a PR in [moonbeam-docs](https://github.com/PureStake/moonbeam-docs) repository.
- [x] If this requires it, I have updated the Readme
- [x] If necessary, I have updated the examples
- [x] I have verified if I need to create/update unit tests
- [x] I have verified if I need to create/update acceptance tests
- [x] If necessary, I have run acceptance tests on this branch in CI
