### PR TITLE
Support substrate addr erc20 balance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16880,6 +16880,7 @@
         "@moonbeam-network/xcm-types": "1.0.1"
       },
       "peerDependencies": {
+        "@polkadot/api": "^10.10.1",
         "@polkadot/types": "^10.10.1",
         "@polkadot/util": "^12.5.1",
         "@polkadot/util-crypto": "^12.5.1"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -54,6 +54,7 @@
     "@moonbeam-network/xcm-types": "1.0.1"
   },
   "peerDependencies": {
+    "@polkadot/api": "^10.10.1",
     "@polkadot/types": "^10.10.1",
     "@polkadot/util": "^12.5.1",
     "@polkadot/util-crypto": "^12.5.1"

--- a/packages/config/src/types/AssetConfig.ts
+++ b/packages/config/src/types/AssetConfig.ts
@@ -6,6 +6,7 @@ import {
   FeeConfigBuilder,
 } from '@moonbeam-network/xcm-builder';
 import { AnyChain, Asset } from '@moonbeam-network/xcm-types';
+import type { ApiPromise } from '@polkadot/api';
 
 export interface AssetConfigConstructorParams {
   asset: Asset;
@@ -16,6 +17,7 @@ export interface AssetConfigConstructorParams {
   extrinsic?: ExtrinsicConfigBuilder;
   fee?: FeeAssetConfig;
   min?: AssetMinConfigBuilder;
+  toEvmAddress?: (api: ApiPromise, address: string) => Promise<string>;
 }
 
 export interface DestinationFeeConfig extends FeeAssetConfig {
@@ -44,6 +46,8 @@ export class AssetConfig {
 
   readonly min?: AssetMinConfigBuilder;
 
+  readonly toEvmAddress?: (api: ApiPromise, address: string) => Promise<string>;
+
   constructor({
     asset,
     balance,
@@ -53,6 +57,7 @@ export class AssetConfig {
     extrinsic,
     fee,
     min,
+    toEvmAddress,
   }: AssetConfigConstructorParams) {
     this.asset = asset;
     this.balance = balance;
@@ -62,5 +67,6 @@ export class AssetConfig {
     this.extrinsic = extrinsic;
     this.fee = fee;
     this.min = min;
+    this.toEvmAddress = toEvmAddress;
   }
 }

--- a/packages/sdk/src/getTransferData/getTransferData.utils.ts
+++ b/packages/sdk/src/getTransferData/getTransferData.utils.ts
@@ -20,8 +20,12 @@ export async function getBalance({
   evmSigner,
   polkadot,
 }: GetFeeBalancesParams) {
+  const addr = config.toEvmAddress
+    ? await config.toEvmAddress(polkadot.api, address)
+    : address;
+
   const cfg = config.balance.build({
-    address,
+    address: addr,
     asset: polkadot.chain.getBalanceAssetId(config.asset),
   });
 
@@ -45,8 +49,12 @@ export async function getDecimals({
   evmSigner,
   polkadot,
 }: GetFeeBalancesParams) {
+  const addr = config.toEvmAddress
+    ? await config.toEvmAddress(polkadot.api, address)
+    : address;
+
   const cfg = config.balance.build({
-    address,
+    address: addr,
     asset: polkadot.chain.getBalanceAssetId(asset || config.asset),
   });
 


### PR DESCRIPTION
### Description

Custom mapper to support erc20 token balance with substrate addr. [See](https://github.com/PureStake/xcm-sdk/issues/128#issuecomment-1749596629)

### Checklist

- [x] If this requires a documentation change, I have created a PR in [moonbeam-docs](https://github.com/PureStake/moonbeam-docs) repository.
- [x] If this requires it, I have updated the Readme
- [x] If necessary, I have updated the examples
- [x] I have verified if I need to create/update unit tests
- [x] I have verified if I need to create/update acceptance tests
- [x] If necessary, I have run acceptance tests on this branch in CI
