### PR TITLE
Adjust weight limit, always use unlimited (fix Bifrost issue)

### DIFF
--- a/.changeset/late-carpets-suffer.md
+++ b/.changeset/late-carpets-suffer.md
@@ -1,0 +1,6 @@
+---
+'@moonbeam-network/xcm-builder': patch
+'@moonbeam-network/xcm-types': patch
+---
+
+Use unlimited weight in all transactions for the xTokens pallet

--- a/packages/builder/src/extrinsic/pallets/xTokens/__snapshots__/xTokens.test.ts.snap
+++ b/packages/builder/src/extrinsic/pallets/xTokens/__snapshots__/xTokens.test.ts.snap
@@ -30,7 +30,7 @@ exports[`xTokens transfer should get correct arguments 1`] = `
       "parents": 1,
     },
   },
-  1000000000,
+  "Unlimited",
 ]
 `;
 
@@ -85,7 +85,7 @@ exports[`xTokens transferMultiAsset parachain should get correct arguments 1`] =
       "parents": 1,
     },
   },
-  1000000000,
+  "Unlimited",
 ]
 `;
 
@@ -188,7 +188,7 @@ exports[`xTokens transferMultiAsset x2 should get correct arguments 1`] = `
       "parents": 1,
     },
   },
-  1000000000,
+  "Unlimited",
 ]
 `;
 

--- a/packages/builder/src/extrinsic/pallets/xTokens/xTokens.ts
+++ b/packages/builder/src/extrinsic/pallets/xTokens/xTokens.ts
@@ -12,7 +12,7 @@ const pallet = 'xTokens';
 export function xTokens() {
   return {
     transfer: (): ExtrinsicConfigBuilder => ({
-      build: ({ address, amount, asset, destination, source }) =>
+      build: ({ address, amount, asset, destination }) =>
         new ExtrinsicConfig({
           module: pallet,
           func: 'transfer',
@@ -23,7 +23,7 @@ export function xTokens() {
               asset,
               amount,
               getDestination(version, address, destination),
-              getWeight(source.weight, func),
+              getWeight(),
             ];
           },
         }),
@@ -55,7 +55,7 @@ export function xTokens() {
                     },
                   },
                   getDestination(version, address, destination),
-                  'Unlimited',
+                  getWeight(),
                 ];
               },
             }),
@@ -87,13 +87,13 @@ export function xTokens() {
                     },
                   },
                   getDestination(version, address, destination),
-                  'Unlimited',
+                  getWeight(),
                 ];
               },
             }),
         }),
         X2: (): ExtrinsicConfigBuilder => ({
-          build: ({ address, amount, asset, destination, source }) =>
+          build: ({ address, amount, asset, destination }) =>
             new ExtrinsicConfig({
               module: pallet,
               func: funcName,
@@ -124,7 +124,7 @@ export function xTokens() {
                     },
                   },
                   getDestination(version, address, destination),
-                  getWeight(source.weight, func),
+                  getWeight(),
                 ];
               },
             }),
@@ -143,7 +143,7 @@ export function xTokens() {
             ],
             1,
             getDestination(XcmVersion.v3, address, destination),
-            'Unlimited',
+            getWeight(),
           ],
         }),
     }),

--- a/packages/builder/src/extrinsic/pallets/xTokens/xTokens.utils.ts
+++ b/packages/builder/src/extrinsic/pallets/xTokens/xTokens.utils.ts
@@ -1,34 +1,13 @@
 import { AnyChain } from '@moonbeam-network/xcm-types';
-import { SubmittableExtrinsicFunction } from '@polkadot/api/types';
 import { XcmVersion } from '../../ExtrinsicBuilder.interfaces';
 import { getExtrinsicAccount } from '../../ExtrinsicBuilder.utils';
 import { XTokensWeightLimit } from './xTokens.interfaces';
 
 /**
- * Workaround for weight parameter type change in xTokens pallet
- * https://github.com/open-web3-stack/open-runtime-module-library/pull/841
+ * It is safer to always use unlimited
  */
-export function getWeight(
-  weight: number,
-  func?: SubmittableExtrinsicFunction<'promise'>,
-): XTokensWeightLimit {
-  const type = func?.meta.args.at(-1)?.type;
-
-  if (!type) {
-    return weight;
-  }
-
-  if (type.eq('XcmV2WeightLimit')) {
-    return {
-      Limited: weight,
-    };
-  }
-
-  if (type.eq('XcmV3WeightLimit')) {
-    return 'Unlimited';
-  }
-
-  return weight;
+export function getWeight(): XTokensWeightLimit {
+  return 'Unlimited';
 }
 
 export function getDestination(

--- a/packages/types/src/chain/parachain/Parachain.ts
+++ b/packages/types/src/chain/parachain/Parachain.ts
@@ -23,7 +23,7 @@ export class Parachain extends Chain {
 
   readonly ss58Format: number;
 
-  readonly weight: number;
+  readonly weight: number | undefined;
 
   readonly ws: string;
 
@@ -46,7 +46,7 @@ export class Parachain extends Chain {
     this.genesisHash = genesisHash;
     this.parachainId = parachainId;
     this.ss58Format = ss58Format;
-    this.weight = weight ?? 1_000_000_000;
+    this.weight = weight;
     this.ws = ws;
   }
 


### PR DESCRIPTION
### Description

Something changed regarding the weight limits in Bifrost, causing an error in the fee calculations. We fix this by using Unlimited as weight limit, just like we do in most other cases

### Checklist

- [x] If this requires a documentation change, I have created a PR in [moonbeam-docs](https://github.com/PureStake/moonbeam-docs) repository.
- [x] If this requires it, I have updated the Readme
- [x] If necessary, I have updated the examples
- [x] I have verified if I need to create/update unit tests
- [x] I have verified if I need to create/update acceptance tests
- [x] If necessary, I have run acceptance tests on this branch in CI
